### PR TITLE
Modify paths to work on /graphql

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -16,5 +16,9 @@ pub async fn serve(
         },
     );
 
-    warp::serve(filter).run(socketaddr).await;
+    let route_graphql = warp::path("graphql").and(warp::any()).and(filter);
+    let route_home = warp::path::end().map(|| "");
+    let routes = warp::post().and(route_graphql.or(route_home));
+
+    warp::serve(routes).run(socketaddr).await;
 }


### PR DESCRIPTION
* Modified pathing on web.rs to work with /graphql and any other paths working with /graphql
* \
```sh
❯ curl 'http://127.0.0.1:8080' \
  -X POST\
  -H 'content-type: application/json' \
  --data '{
    "query": "{ issues }"
  }'
```
* \graphql
```sh
❯ curl 'http://127.0.0.1:8080/graphql' \
  -X POST\
  -H 'content-type: application/json' \
  --data '{
    "query": "{ issues }"
  }'
{"data":{"issues":[]}}%  
```
* \graphql\5
```sh
❯ curl 'http://127.0.0.1:8080/graphql/5' \
  -X POST\
  -H 'content-type: application/json' \
  --data '{
    "query": "{ issues }"
  }'
{"data":{"issues":[]}}%  
```