### PR TITLE
Separate command-line parsing from `main`

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -36,7 +36,6 @@ pub struct Config {
 }
 
 pub const PKG_NAME: &str = env!("CARGO_PKG_NAME");
-pub const PKG_VER: &str = env!("CARGO_PKG_VERSION");
 
 pub fn load_config(path: &Path) -> Result<Config> {
     let mut config_str = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use database::Database;
 use directories::ProjectDirs;
 use github::{send_github_issue_query, send_github_pr_query};
 use google::check_key;
-use std::env;
 use std::path::PathBuf;
 use std::process::exit;
 use tokio::{task, time};
@@ -35,25 +34,12 @@ const ONE_HOUR: u64 = 60 * 60;
 const ORGANIZATION: &str = "einsis";
 const QUALIFIER: &str = "com";
 
-#[allow(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() {
     println!("AICE GitHub Dashboard Server");
 
-    let mut usage_args = env::args();
-
-    let path = if let Some(args_val) = usage_args.nth(1) {
-        match args_val.as_str() {
-            "-V" | "--version" => {
-                println!("{} {}", conf::PKG_NAME, conf::PKG_VER);
-                exit(0);
-            }
-            "-h" | "--help" => {
-                println!("{}", USAGE);
-                exit(0);
-            }
-            _ => PathBuf::from(args_val),
-        }
+    let config_filename = if let Some(config_filename) = parse() {
+        PathBuf::from(config_filename)
     } else if let Some(proj_dirs) = ProjectDirs::from(QUALIFIER, ORGANIZATION, PKG_NAME) {
         proj_dirs.config_dir().join(DEFAULT_CONFIG)
     } else {
@@ -61,7 +47,7 @@ async fn main() {
         exit(1);
     };
 
-    let config = match load_config(&path) {
+    let config = match load_config(&config_filename) {
         Ok(ret) => ret,
         Err(error) => {
             eprintln!("Problem while loading config. {}", error);
@@ -143,4 +129,33 @@ async fn main() {
 
     let schema = graphql::schema(database);
     web::serve(schema, socket_addr).await;
+}
+
+/// Parses the command line arguments and returns the first argument.
+fn parse() -> Option<String> {
+    use std::env;
+
+    let mut args = env::args();
+    args.next()?;
+    let arg = args.next()?;
+    if args.next().is_some() {
+        eprintln!("Error: too many arguments");
+        exit(1);
+    }
+
+    if arg == "--help" || arg == "-h" {
+        print!("{}", USAGE);
+        exit(0);
+    }
+    if arg == "--version" || arg == "-V" {
+        println!("github-dashboard-server {}", env!("CARGO_PKG_VERSION"));
+        exit(0);
+    }
+    if arg.starts_with('-') {
+        eprintln!("Error: unknown option: {}", arg);
+        eprintln!("\n{}", USAGE);
+        exit(1);
+    }
+
+    Some(arg)
 }


### PR DESCRIPTION
This change shortens `main` and thus `allow(clippy::too_many_lines)`
is no longer necessary.