### PR TITLE
Rename functions that don't follow Rust API Guidelines

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -110,7 +110,7 @@ impl Database {
         Ok(())
     }
 
-    pub fn get_prev_exist(key: String, tree: &Tree) -> Result<bool> {
+    pub fn has_prev(key: String, tree: &Tree) -> Result<bool> {
         if tree.get_lt(key)?.is_some() {
             Ok(true)
         } else {
@@ -118,7 +118,7 @@ impl Database {
         }
     }
 
-    pub fn get_next_exist(key: String, tree: &Tree) -> Result<bool> {
+    pub fn has_next(key: String, tree: &Tree) -> Result<bool> {
         if tree.get_gt(key)?.is_some() {
             Ok(true)
         } else {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -151,8 +151,8 @@ where
     if let Some(prev_val) = prev {
         if let Some(next_val) = next {
             return Ok((
-                Database::get_prev_exist(format!("{}", prev_val), tree)?,
-                Database::get_next_exist(format!("{}", next_val), tree)?,
+                Database::has_prev(format!("{}", prev_val), tree)?,
+                Database::has_next(format!("{}", next_val), tree)?,
             ));
         }
     }


### PR DESCRIPTION
In [Getter names follow Rust convention (C-GETTER)](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter):

> With a few exceptions, the `get_` prefix is not used for getters in Rust code.