### PR TITLE
Remove redundant argument

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -126,7 +126,8 @@ impl Database {
         }
     }
 
-    pub fn select_issue_range(p_type: PagingType, tree: &Tree) -> Result<Vec<Issue>> {
+    pub fn select_issue_range(&self, p_type: PagingType) -> Result<Vec<Issue>> {
+        let tree = &self.issue_tree;
         let mut range_list: Vec<(IVec, IVec)>;
         match p_type {
             PagingType::All => {
@@ -173,7 +174,8 @@ impl Database {
         get_issue_list(range_list)
     }
 
-    pub fn select_pr_range(p_type: PagingType, tree: &Tree) -> Result<Vec<PullRequest>> {
+    pub fn select_pr_range(&self, p_type: PagingType) -> Result<Vec<PullRequest>> {
+        let tree = &self.pr_tree;
         let mut range_list: Vec<(IVec, IVec)>;
         match p_type {
             PagingType::All => {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -73,7 +73,7 @@ impl Query {
                     Err(e) => bail!("{:?}", e),
                 };
                 let p_type = check_paging_type(after, before, first, last)?;
-                let select_vec = Database::select_issue_range(p_type, tree)?;
+                let select_vec = db.select_issue_range(p_type)?;
                 let (prev, next) =
                     check_prev_next_exist(select_vec.first(), select_vec.last(), tree)?;
                 Ok(connect_cursor(select_vec, prev, next))
@@ -112,7 +112,7 @@ impl Query {
                 };
 
                 let p_type = check_paging_type(after, before, first, last)?;
-                let select_vec = Database::select_pr_range(p_type, tree)?;
+                let select_vec = db.select_pr_range(p_type)?;
                 let (prev, next) =
                     check_prev_next_exist(select_vec.first(), select_vec.last(), tree)?;
                 Ok(connect_cursor(select_vec, prev, next))


### PR DESCRIPTION
Functions names (`select_issue_range` and `select_pr_range`) implies
what `Tree` each function should use, and thus there is no need to
pass the `Tree` as an argument.