### PR TITLE
Remove unnecessary `allow(non_snake_case)`

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -83,8 +83,7 @@ impl Query {
         }
     }
 
-    #[allow(non_snake_case)]
-    pub async fn pullRequests<'ctx>(
+    pub async fn pull_requests<'ctx>(
         &self,
         ctx: &Context<'ctx>,
         after: Option<String>,


### PR DESCRIPTION
async-graphql converts a function name to CamelCase automatically.