### PR TITLE
Decouple web module from graphql

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -2,12 +2,14 @@ use crate::database::Database;
 use anyhow::{anyhow, bail, Result};
 use async_graphql::{
     types::connection::{query, Connection, Edge, EmptyFields},
-    Context, EmptyMutation, EmptySubscription, Object, OutputType, Schema, SimpleObject,
+    Context, EmptyMutation, EmptySubscription, Object, OutputType, SimpleObject,
 };
 use sled::Tree;
 use std::fmt::Display;
 
 pub struct Query;
+
+pub type Schema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;
 
 #[derive(Debug, SimpleObject)]
 pub struct Issue {
@@ -178,7 +180,7 @@ fn check_paging_type(
     Ok(PagingType::All)
 }
 
-pub fn schema(database: Database) -> Schema<Query, EmptyMutation, EmptySubscription> {
+pub fn schema(database: Database) -> Schema {
     Schema::build(Query, EmptyMutation, EmptySubscription)
         .data(database)
         .finish()

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,22 +1,12 @@
-use crate::graphql;
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use crate::graphql::Schema;
+use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 
 use std::{convert::Infallible, net::SocketAddr};
 use warp::{http::Response as HttpResponse, Filter};
 
-pub async fn serve(
-    schema: Schema<graphql::Query, EmptyMutation, EmptySubscription>,
-    socketaddr: SocketAddr,
-    key: &str,
-    cert: &str,
-) {
-    type MySchema = Schema<graphql::Query, EmptyMutation, EmptySubscription>;
-
+pub async fn serve(schema: Schema, socketaddr: SocketAddr, key: &str, cert: &str) {
     let filter = async_graphql_warp::graphql(schema).and_then(
-        |(schema, request): (MySchema, async_graphql::Request)| async move {
+        |(schema, request): (Schema, async_graphql::Request)| async move {
             let resp = schema.execute(request).await;
 
             Ok::<_, Infallible>(async_graphql_warp::GraphQLResponse::from(resp))


### PR DESCRIPTION
This allows to change the GraphQL schema (e.g., adding mutations) without modifying web.rs.