### PR TITLE
Use `Path` to represent a path

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
 use serde::Serialize;
 use sled::{Db, IVec, Tree};
+use std::path::Path;
 
 const ISSUE_TREE_NAME: &str = "issues";
 const PULL_REQUEST_TREE_NAME: &str = "pull_requests";
@@ -18,7 +19,7 @@ pub struct Database {
 }
 
 impl Database {
-    fn connect_db(path: &str) -> Result<Db> {
+    fn connect_db(path: &Path) -> Result<Db> {
         Ok(sled::open(path)?)
     }
 
@@ -28,7 +29,7 @@ impl Database {
         Ok((issue_tree, pull_request_tree))
     }
 
-    pub fn connect(db_path: &str) -> Result<Database> {
+    pub fn connect(db_path: &Path) -> Result<Database> {
         let db = Database::connect_db(db_path)?;
         let (issue_tree, pull_request_tree) = Database::connect_trees(&db)?;
         Ok(Database {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
         }
     };
 
-    let database = match Database::connect(&config.database.db_name) {
+    let database = match Database::connect(config.database.db_name.as_ref()) {
         Ok(ret) => ret,
         Err(error) => {
             eprintln!("Problem while Connect Sled Database. {}", error);


### PR DESCRIPTION
Using a more concrete type like [`Path`](https://doc.rust-lang.org/std/path/struct.Path.html) rather than a general type like `str` makes the intention of the code clearer.