### PR TITLE
Remove unnecessary `pub`

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -53,7 +53,7 @@ impl Display for PullRequest {
 
 #[Object]
 impl Query {
-    pub async fn issues<'ctx>(
+    async fn issues<'ctx>(
         &self,
         ctx: &Context<'ctx>,
         after: Option<String>,
@@ -85,7 +85,7 @@ impl Query {
         }
     }
 
-    pub async fn pull_requests<'ctx>(
+    async fn pull_requests<'ctx>(
         &self,
         ctx: &Context<'ctx>,
         after: Option<String>,


### PR DESCRIPTION
Functions for async-graphql queries don't need to be public.