### PR TITLE
Set default page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Tracing with a filter set by `RUST_LOG` environment variable.
 
+### Changed
+
+- GraphQL API `issues` and `pullRequests` return 100 items if neither `first`
+  nor `last` is specified.
+
 ### Fixed
 
 - Returns an error instead of an issue with "No title" as the title when the

--- a/src/database.rs
+++ b/src/database.rs
@@ -140,12 +140,6 @@ impl Database {
         let tree = &self.issue_tree;
         let mut range_list: Vec<(IVec, IVec)>;
         match p_type {
-            PagingType::All => {
-                range_list = tree
-                    .iter()
-                    .filter_map(std::result::Result::ok)
-                    .collect::<Vec<(IVec, IVec)>>();
-            }
             PagingType::First(f_val) => {
                 range_list = tree
                     .iter()
@@ -188,12 +182,6 @@ impl Database {
         let tree = &self.pull_request_tree;
         let mut range_list: Vec<(IVec, IVec)>;
         match p_type {
-            PagingType::All => {
-                range_list = tree
-                    .iter()
-                    .filter_map(std::result::Result::ok)
-                    .collect::<Vec<(IVec, IVec)>>();
-            }
             PagingType::First(f_val) => {
                 range_list = tree
                     .iter()


### PR DESCRIPTION
This limits the number of connections when neither `first` nor `last` is provided. Returning all the avaialbe issues/pull requests should be avoided because it might cause too much burden on the server or network.