### PR TITLE
Enforce import grouping in formatting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,17 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: stable
-    - uses: actions/checkout@v2
-    - name: Check formatting
-      run: cargo fmt -- --check
-    - name: Clippy
-      run: cargo clippy -- -D warnings -W clippy::pedantic
-    - name: markdownlint
-      uses: articulate/actions-markdownlint@v1
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - uses: actions/checkout@v2
+      - name: Check formatting
+        run: cargo fmt -- --check --config group_imports=StdExternalCrate
+      - name: Clippy
+        run: cargo clippy -- -D warnings -W clippy::pedantic
+      - name: markdownlint
+        uses: articulate/actions-markdownlint@v1
 
   test:
     runs-on: ${{ matrix.os }}
@@ -27,15 +27,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: stable
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
 
   coverage:
     runs-on: ubuntu-latest
@@ -43,9 +43,9 @@ jobs:
       image: xd009642/tarpaulin
       options: --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@v2
-    - name: Generate code coverage
-      run: |
-        cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      - uses: actions/checkout@v2
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2

--- a/src/checkout.rs
+++ b/src/checkout.rs
@@ -1,15 +1,17 @@
-use crate::conf::RepoInfo;
-use anyhow::{anyhow, Result};
-use directories::ProjectDirs;
-use git2::{Cred, FetchOptions, RemoteCallbacks, Repository};
 use std::time::Duration;
 use std::{
     env::var,
     path::{Path, PathBuf},
     sync::Arc,
 };
+
+use anyhow::{anyhow, Result};
+use directories::ProjectDirs;
+use git2::{Cred, FetchOptions, RemoteCallbacks, Repository};
 use tokio::time;
 use tracing::{error, info};
+
+use crate::conf::RepoInfo;
 
 const FETCH_HEAD: &str = "FETCH_HEAD";
 const LOCAL_BASE_REPO: &str = "repos";

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,10 +1,11 @@
-use anyhow::{anyhow, bail, Result};
-use serde::Deserialize;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::Path;
+
+use anyhow::{anyhow, bail, Result};
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct ServerAddr {

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,13 +1,14 @@
-use crate::{
-    github::{GitHubIssue, GitHubPullRequests},
-    graphql::{Issue, PullRequest},
-};
+use std::{marker::PhantomData, path::Path};
+
 use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
 use serde::Serialize;
 use sled::{Db, Tree};
-use std::{marker::PhantomData, path::Path};
 
+use crate::{
+    github::{GitHubIssue, GitHubPullRequests},
+    graphql::{Issue, PullRequest},
+};
 const ISSUE_TREE_NAME: &str = "issues";
 const PULL_REQUEST_TREE_NAME: &str = "pull_requests";
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,16 +1,17 @@
-use crate::github::{
-    open_issues::OpenIssuesRepositoryIssuesNodesAuthor::User as userName,
-    pull_requests::PullRequestsRepositoryPullRequestsNodesReviewRequestsNodesRequestedReviewer::User,
-};
+use std::{sync::Arc, time::Duration};
+
 use anyhow::{bail, Result};
 use chrono::Utc;
 use graphql_client::{GraphQLQuery, QueryBody, Response as GraphQlResponse};
 use reqwest::{Client, RequestBuilder, Response};
 use serde::Serialize;
-use std::{sync::Arc, time::Duration};
 use tokio::time;
 use tracing::error;
 
+use crate::github::{
+    open_issues::OpenIssuesRepositoryIssuesNodesAuthor::User as userName,
+    pull_requests::PullRequestsRepositoryPullRequestsNodesReviewRequestsNodesRequestedReviewer::User,
+};
 use crate::{conf::RepoInfo, database::Database};
 
 const GITHUB_FETCH_SIZE: i64 = 10;

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,14 +1,16 @@
 mod issue;
 mod pull_request;
 
-pub use self::issue::Issue;
-pub use self::pull_request::PullRequest;
-use crate::database::Database;
+use std::fmt::Display;
+
 use async_graphql::{
     types::connection::{Connection, Edge, EmptyFields},
     Context, EmptyMutation, EmptySubscription, MergedObject, OutputType, Result,
 };
-use std::fmt::Display;
+
+pub use self::issue::Issue;
+pub use self::pull_request::PullRequest;
+use crate::database::Database;
 
 /// The default page size for connections when neither `first` nor `last` is
 /// provided.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,15 +6,17 @@ mod google;
 mod graphql;
 mod web;
 
-use crate::conf::PKG_NAME;
+use std::path::PathBuf;
+use std::process::exit;
+use std::sync::Arc;
+
 use conf::{load_config, parse_socket_addr};
 use database::Database;
 use directories::ProjectDirs;
 use google::check_key;
-use std::path::PathBuf;
-use std::process::exit;
-use std::sync::Arc;
 use tokio::{task, time};
+
+use crate::conf::PKG_NAME;
 
 const USAGE: &str = "\
 USAGE:

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,8 +1,9 @@
-use crate::graphql::Schema;
-use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
-
 use std::{convert::Infallible, net::SocketAddr};
+
+use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use warp::{http::Response as HttpResponse, Filter};
+
+use crate::graphql::Schema;
 
 pub async fn serve(schema: Schema, socketaddr: SocketAddr, key: &str, cert: &str) {
     let filter = async_graphql_warp::graphql(schema).and_then(


### PR DESCRIPTION
Closes #109
- Added `cargo fmt -- --check --config group_imports=StdExternalCrate` to `ci.yml` to enforce standardized import grouping. 
- Reformatted source files to comply with this rule.