### PR TITLE
Minimize unnecessary pub access modifiers

### DIFF
--- a/src/checkout.rs
+++ b/src/checkout.rs
@@ -76,7 +76,11 @@ fn pull_repo(name: &str, ssh: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn fetch_periodically(repositories: Arc<Vec<RepoInfo>>, duration: Duration, ssh: String) {
+pub(super) async fn fetch_periodically(
+    repositories: Arc<Vec<RepoInfo>>,
+    duration: Duration,
+    ssh: String,
+) {
     for repo_info in repositories.iter() {
         if let Err(error) = init_repo(&repo_info.owner, &repo_info.name, &ssh) {
             error!("{}", error);

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -8,40 +8,40 @@ use anyhow::{anyhow, bail, Result};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-pub struct ServerAddr {
-    pub address: String,
-    pub key: String,
-    pub cert: String,
+pub(super) struct ServerAddr {
+    pub(super) address: String,
+    pub(super) key: String,
+    pub(super) cert: String,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct RepoInfo {
-    pub owner: String,
-    pub name: String,
+pub(super) struct RepoInfo {
+    pub(super) owner: String,
+    pub(super) name: String,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Certification {
-    pub token: String,
-    pub ssh: String,
+pub(super) struct Certification {
+    pub(super) token: String,
+    pub(super) ssh: String,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Database {
-    pub db_path: String,
+pub(super) struct Database {
+    pub(super) db_path: String,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Config {
-    pub web: ServerAddr,
-    pub repositories: Vec<RepoInfo>,
-    pub certification: Certification,
-    pub database: Database,
+pub(super) struct Config {
+    pub(super) web: ServerAddr,
+    pub(super) repositories: Vec<RepoInfo>,
+    pub(super) certification: Certification,
+    pub(super) database: Database,
 }
 
-pub const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+pub(super) const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 
-pub fn load_config(path: &Path) -> Result<Config> {
+pub(super) fn load_config(path: &Path) -> Result<Config> {
     let mut config_str = String::new();
 
     if let Err(e) = File::open(path).and_then(|mut f| f.read_to_string(&mut config_str)) {
@@ -59,7 +59,7 @@ pub fn load_config(path: &Path) -> Result<Config> {
     Ok(config)
 }
 
-pub fn parse_socket_addr(addr_str: &str) -> Result<SocketAddr> {
+pub(super) fn parse_socket_addr(addr_str: &str) -> Result<SocketAddr> {
     let socket_addr: SocketAddr;
     if let Ok(mut addr_iter) = addr_str.to_socket_addrs() {
         if let Some(s_addr) = addr_iter.next() {

--- a/src/github.rs
+++ b/src/github.rs
@@ -27,32 +27,32 @@ type DateTime = String;
     query_path = "src/open_issues.graphql",
     response_derives = "Debug"
 )]
-pub struct OpenIssues;
+struct OpenIssues;
 
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/github_schema.graphql",
     query_path = "src/pull_requests.graphql"
 )]
-pub struct PullRequests;
+struct PullRequests;
 
 #[derive(Debug)]
-pub struct GitHubIssue {
-    pub number: i64,
-    pub title: String,
-    pub author: String,
-    pub closed_at: Option<DateTime>,
+pub(super) struct GitHubIssue {
+    pub(super) number: i64,
+    pub(super) title: String,
+    pub(super) author: String,
+    pub(super) closed_at: Option<DateTime>,
 }
 
 #[derive(Debug)]
-pub struct GitHubPullRequests {
-    pub number: i64,
-    pub title: String,
-    pub assignees: Vec<String>,
-    pub reviewers: Vec<String>,
+pub(super) struct GitHubPullRequests {
+    pub(super) number: i64,
+    pub(super) title: String,
+    pub(super) assignees: Vec<String>,
+    pub(super) reviewers: Vec<String>,
 }
 
-pub async fn fetch_periodically(
+pub(super) async fn fetch_periodically(
     repositories: Arc<Vec<RepoInfo>>,
     token: String,
     period: Duration,

--- a/src/google.rs
+++ b/src/google.rs
@@ -7,7 +7,7 @@ use crate::database::Database;
 const GOOGLE_PUBLIC_KEY: &str = "https://www.googleapis.com/oauth2/v3/certs";
 const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
-pub async fn check_key(db: &Database) -> Result<bool> {
+pub(super) async fn check_key(db: &Database) -> Result<bool> {
     let result = get_key().await;
     match result {
         Ok(response) => {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -9,8 +9,8 @@ use async_graphql::{
 };
 use base64::{engine::general_purpose, Engine as _};
 
-pub use self::issue::Issue;
-pub use self::pull_request::PullRequest;
+pub(crate) use self::issue::Issue;
+pub(crate) use self::pull_request::PullRequest;
 use crate::database::Database;
 
 /// The default page size for connections when neither `first` nor `last` is
@@ -21,9 +21,9 @@ const DEFAULT_PAGE_SIZE: usize = 100;
 ///
 /// This is exposed only for [`Schema`], and not used directly.
 #[derive(Default, MergedObject)]
-pub struct Query(issue::IssueQuery, pull_request::PullRequestQuery);
+pub(crate) struct Query(issue::IssueQuery, pull_request::PullRequestQuery);
 
-pub type Schema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;
+pub(crate) type Schema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;
 
 fn connect_cursor<T>(
     select_vec: Vec<T>,
@@ -44,7 +44,7 @@ where
     connection
 }
 
-pub fn schema(database: Database) -> Schema {
+pub(crate) fn schema(database: Database) -> Schema {
     Schema::build(Query::default(), EmptyMutation, EmptySubscription)
         .data(database)
         .finish()

--- a/src/graphql/issue.rs
+++ b/src/graphql/issue.rs
@@ -9,12 +9,12 @@ use async_graphql::{
 use crate::database::{self, Database, TryFromKeyValue};
 
 #[derive(SimpleObject)]
-pub struct Issue {
-    pub owner: String,
-    pub repo: String,
-    pub number: i32,
-    pub title: String,
-    pub author: String,
+pub(crate) struct Issue {
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) number: i32,
+    pub(crate) title: String,
+    pub(crate) author: String,
 }
 
 impl TryFromKeyValue for Issue {

--- a/src/graphql/pull_request.rs
+++ b/src/graphql/pull_request.rs
@@ -9,13 +9,13 @@ use async_graphql::{
 use crate::database::{self, Database, TryFromKeyValue};
 
 #[derive(SimpleObject)]
-pub struct PullRequest {
-    pub owner: String,
-    pub repo: String,
-    pub number: i32,
-    pub title: String,
-    pub assignees: Vec<String>,
-    pub reviewers: Vec<String>,
+pub(crate) struct PullRequest {
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+    pub(crate) number: i32,
+    pub(crate) title: String,
+    pub(crate) assignees: Vec<String>,
+    pub(crate) reviewers: Vec<String>,
 }
 
 impl TryFromKeyValue for PullRequest {

--- a/src/web.rs
+++ b/src/web.rs
@@ -5,7 +5,7 @@ use warp::{http::Response as HttpResponse, Filter};
 
 use crate::graphql::Schema;
 
-pub async fn serve(schema: Schema, socketaddr: SocketAddr, key: &str, cert: &str) {
+pub(super) async fn serve(schema: Schema, socketaddr: SocketAddr, key: &str, cert: &str) {
     let filter = async_graphql_warp::graphql(schema).and_then(
         |(schema, request): (Schema, async_graphql::Request)| async move {
             let resp = schema.execute(request).await;


### PR DESCRIPTION
Closes #121

다음과 같은 기조로 접근자를 변경했습니다.

clippy 상으로 unnecessary pub access 진단이 나오는 코드 중,

1. parent mod에서만 사용되고 있어 pub(super)를 적용가능한 함수 / 모듈은 전부 pub(super) 적용
2. 반대로 crate 내부에서 참조되고 있는 코드들은 pub(crate) 적용.
3. 그 외에 #[allow(unused)] 매크로가 사용되었거나 crate 내부 참조가 없는 코드는 pub을 삭제했습니다.
