### PR TITLE
Fix config parsing to db_path instead of db_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Configuration key `db_name` has been renamed to `db_path`.
 - GraphQL API `issues` and `pullRequests` return 100 items if neither `first`
   nor `last` is specified.
 - GraphQL API `issues` and `pullRequests` return an error if conflicting

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -28,7 +28,7 @@ pub struct Certification {
 
 #[derive(Debug, Deserialize)]
 pub struct Database {
-    pub db_name: String,
+    pub db_path: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ async fn main() {
         }
     };
 
-    let database = match Database::connect(config.database.db_name.as_ref()) {
+    let database = match Database::connect(config.database.db_path.as_ref()) {
         Ok(ret) => ret,
         Err(error) => {
             eprintln!("Problem while Connect Sled Database. {error}");


### PR DESCRIPTION
## Related Issue

closes #120

## PR Description
- `db_name`이 아닌 `db_path` 를 참조하도록 수정했습니다.