### PR TITLE
Support SSH passphrase via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ this project adheres to
 ### Added
 
 - Tracing with a filter set by `RUST_LOG` environment variable.
+- Added support for passing the SSH passphrase through the `SSH_PASSPHRASE`
+  environment variable.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ db_path = "db_path"
   - Issues: Read-only access
   - Pull Requests: Read-only access
 - `ssh`: The path to SSH private key for GitHub code checkout.
+  - To provide an SSH passphrase, set the `SSH_PASSPHRASE` environment variable.
 - `db_path`: The path to the database for creation/connection.
 
 ### Running the App

--- a/src/checkout.rs
+++ b/src/checkout.rs
@@ -18,12 +18,20 @@ const LOCAL_BASE_REPO: &str = "repos";
 const MAIN_BRANCH: &str = "main";
 const REMOTE_NAME: &str = "origin";
 const REMOTE_BASE_URL: &str = "git@github.com";
+const ENV_HOME: &str = "HOME";
+const ENV_SSH_PASSPHRASE: &str = "SSH_PASSPHRASE";
 
 fn callbacks(ssh: &str) -> Result<RemoteCallbacks> {
     let mut callbacks = RemoteCallbacks::new();
-    let ssh_path = Path::new(&var("HOME")?).join(ssh);
+    let ssh_path = Path::new(&var(ENV_HOME)?).join(ssh);
+    let passphrase = std::env::var(ENV_SSH_PASSPHRASE).ok();
     callbacks.credentials(move |_url, username_from_url, _allowed_types| {
-        Cred::ssh_key(username_from_url.unwrap(), None, &ssh_path, None)
+        Cred::ssh_key(
+            username_from_url.unwrap(),
+            None,
+            &ssh_path,
+            passphrase.as_deref(),
+        )
     });
     Ok(callbacks)
 }


### PR DESCRIPTION
## Related Issue
- Close #127
## PR Description
- Implemented support for SSH passphrase using the `SSH_PASSPHRASE` environment variable.
  - Set the SSH passphrase using the following command:
    ```bash
    export SSH_PASSPHRASE="your_passphrase"
    ```
  - If not set, the program will proceed without it.
- Updated README with instructions on setting the SSH passphrase.
- Modified Changelog to reflect the new feature.