### PR TITLE
Add Discussions GraphQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added additional fields to the `issues` GraphQL query, providing detailed information
   such as comments, labels, related sub-issues, linked pull requests, issue descriptions,
   timestamps, and project-related metadata.
+- Exposed a new `discussions` query in the server’s GraphQL API to query the
+  stored discussion data.
 
 ### Changed
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -5,18 +5,25 @@ use regex::Regex;
 use serde::Serialize;
 use sled::{Db, Tree};
 
+pub mod discussion;
+
+pub(crate) use discussion::DiscussionDbSchema;
+
 use crate::{
     github::{GitHubIssue, GitHubPullRequests},
     graphql::{issue::Issue, pull_request::PullRequest},
 };
+
 const ISSUE_TREE_NAME: &str = "issues";
 const PULL_REQUEST_TREE_NAME: &str = "pull_requests";
+const DISCUSSION_TREE_NAME: &str = "discussions";
 
 #[derive(Clone)]
 pub(crate) struct Database {
     db: Db,
     issue_tree: Tree,
     pull_request_tree: Tree,
+    discussion_tree: Tree,
 }
 
 impl Database {
@@ -24,19 +31,21 @@ impl Database {
         Ok(sled::open(path)?)
     }
 
-    fn connect_trees(db: &Db) -> Result<(Tree, Tree)> {
+    fn connect_trees(db: &Db) -> Result<(Tree, Tree, Tree)> {
         let issue_tree = db.open_tree(ISSUE_TREE_NAME)?;
         let pull_request_tree = db.open_tree(PULL_REQUEST_TREE_NAME)?;
-        Ok((issue_tree, pull_request_tree))
+        let discussion_tree = db.open_tree(DISCUSSION_TREE_NAME)?;
+        Ok((issue_tree, pull_request_tree, discussion_tree))
     }
 
     pub(crate) fn connect(db_path: &Path) -> Result<Database> {
         let db = Database::connect_db(db_path)?;
-        let (issue_tree, pull_request_tree) = Database::connect_trees(&db)?;
+        let (issue_tree, pull_request_tree, discussion_tree) = Database::connect_trees(&db)?;
         Ok(Database {
             db,
             issue_tree,
             pull_request_tree,
+            discussion_tree,
         })
     }
 

--- a/src/database/discussion.rs
+++ b/src/database/discussion.rs
@@ -1,0 +1,365 @@
+use std::num::TryFromIntError;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::{Database, Iter};
+use crate::github::discussions::{
+    DiscussionsRepositoryDiscussionsNodes, DiscussionsRepositoryDiscussionsNodesAnswer,
+    DiscussionsRepositoryDiscussionsNodesAnswerAuthor,
+    DiscussionsRepositoryDiscussionsNodesAnswerReplies,
+    DiscussionsRepositoryDiscussionsNodesAnswerRepliesNodesAuthor,
+    DiscussionsRepositoryDiscussionsNodesAuthor, DiscussionsRepositoryDiscussionsNodesComments,
+    DiscussionsRepositoryDiscussionsNodesCommentsNodes,
+    DiscussionsRepositoryDiscussionsNodesCommentsNodesAuthor,
+    DiscussionsRepositoryDiscussionsNodesCommentsNodesReactions,
+    DiscussionsRepositoryDiscussionsNodesCommentsNodesReplies,
+    DiscussionsRepositoryDiscussionsNodesCommentsNodesRepliesNodesAuthor,
+    DiscussionsRepositoryDiscussionsNodesLabels, DiscussionsRepositoryDiscussionsNodesReactions,
+    ReactionContent,
+};
+use crate::graphql::Discussion;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DiscussionDbSchema {
+    pub(crate) number: i32,
+    pub(crate) title: String,
+    pub(crate) author: String,
+    pub(crate) body: String,
+    pub(crate) url: String,
+    pub(crate) created_at: String,
+    pub(crate) updated_at: String,
+    pub(crate) is_answered: bool,
+    pub(crate) answer_chosen_at: Option<String>,
+    pub(crate) answer: Option<Answer>,
+    pub(crate) category: Category,
+    pub(crate) labels: Option<Labels>,
+    pub(crate) comments: Comments,
+    pub(crate) reactions: Reactions,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Answer {
+    pub(crate) body: String,
+    pub(crate) created_at: String,
+    pub(crate) updated_at: String,
+    pub(crate) url: String,
+    pub(crate) author: String,
+    pub(crate) replies: Replies,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Labels {
+    pub(crate) nodes: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Comments {
+    pub(crate) total_count: i32,
+    pub(crate) nodes: Vec<Comment>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Comment {
+    pub(crate) body: String,
+    pub(crate) author: String,
+    pub(crate) created_at: String,
+    pub(crate) updated_at: String,
+    pub(crate) deleted_at: Option<String>,
+    pub(crate) is_answer: bool,
+    pub(crate) is_minimized: bool,
+    pub(crate) last_edited_at: Option<String>,
+    pub(crate) published_at: Option<String>,
+    pub(crate) reactions: Reactions,
+    pub(crate) replies: Replies,
+    pub(crate) upvote_count: i32,
+    pub(crate) url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Reactions {
+    pub(crate) total_count: i32,
+    pub(crate) nodes: Vec<Reaction>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Reaction {
+    pub(crate) content: ReactionContent,
+    pub(crate) created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Replies {
+    pub(crate) total_count: i32,
+    pub(crate) nodes: Vec<Reply>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Reply {
+    pub(crate) body: String,
+    pub(crate) created_at: String,
+    pub(crate) updated_at: String,
+    pub(crate) is_answer: bool,
+    pub(crate) author: String,
+}
+
+impl Database {
+    pub(crate) fn insert_discussions(
+        &self,
+        resp: Vec<DiscussionDbSchema>,
+        owner: &str,
+        repo: &str,
+    ) -> Result<()> {
+        for item in resp {
+            let keystr: String = format!("{owner}/{repo}#{}", item.number);
+            Database::insert(&keystr, item, &self.discussion_tree)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn discussions(&self, start: Option<&[u8]>, end: Option<&[u8]>) -> Iter<Discussion> {
+        let start = start.unwrap_or(b"\x00");
+        if let Some(end) = end {
+            self.discussion_tree.range(start..end).into()
+        } else {
+            self.discussion_tree.range(start..).into()
+        }
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodes> for DiscussionDbSchema {
+    type Error = TryFromIntError;
+
+    fn try_from(discussion: DiscussionsRepositoryDiscussionsNodes) -> Result<Self, Self::Error> {
+        let author = match discussion.author {
+            Some(DiscussionsRepositoryDiscussionsNodesAuthor::User(author)) => author.login,
+            _ => String::default(),
+        };
+
+        let answer = discussion.answer.map(Answer::try_from).transpose()?;
+
+        Ok(Self {
+            number: i32::try_from(discussion.number)?,
+            title: discussion.title,
+            author,
+            body: discussion.body,
+            url: discussion.url,
+            created_at: discussion.created_at.to_string(),
+            updated_at: discussion.updated_at.to_string(),
+            is_answered: discussion.is_answered.unwrap_or(false),
+            answer_chosen_at: discussion.answer_chosen_at.map(|dt| dt.to_string()),
+            answer,
+            category: Category {
+                name: discussion.category.name,
+            },
+            labels: discussion.labels.map(Labels::from),
+            comments: Comments::try_from(discussion.comments)?,
+            reactions: Reactions::try_from(discussion.reactions)?,
+        })
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodesAnswer> for Answer {
+    type Error = TryFromIntError;
+
+    fn try_from(answer: DiscussionsRepositoryDiscussionsNodesAnswer) -> Result<Self, Self::Error> {
+        let author = match answer.author {
+            Some(DiscussionsRepositoryDiscussionsNodesAnswerAuthor::User(author)) => author.login,
+            _ => String::default(),
+        };
+        Ok(Self {
+            body: answer.body,
+            created_at: answer.created_at.to_string(),
+            updated_at: answer.updated_at.to_string(),
+            url: answer.url,
+            author,
+            replies: Replies::try_from(answer.replies)?,
+        })
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodesComments> for Comments {
+    type Error = TryFromIntError;
+
+    fn try_from(
+        comments: DiscussionsRepositoryDiscussionsNodesComments,
+    ) -> Result<Self, Self::Error> {
+        let total_count = i32::try_from(comments.total_count)?;
+
+        let nodes = comments
+            .nodes
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(Comment::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { total_count, nodes })
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodesCommentsNodes> for Comment {
+    type Error = TryFromIntError;
+
+    fn try_from(
+        comment: DiscussionsRepositoryDiscussionsNodesCommentsNodes,
+    ) -> Result<Self, Self::Error> {
+        let author = match comment.author {
+            Some(DiscussionsRepositoryDiscussionsNodesCommentsNodesAuthor::User(author)) => {
+                author.login
+            }
+            _ => String::default(),
+        };
+        Ok(Self {
+            body: comment.body,
+            author,
+            created_at: comment.created_at.to_string(),
+            updated_at: comment.updated_at.to_string(),
+            deleted_at: comment.deleted_at.map(|dt| dt.to_string()),
+            is_answer: comment.is_answer,
+            is_minimized: comment.is_minimized,
+            last_edited_at: comment.last_edited_at.map(|dt| dt.to_string()),
+            published_at: comment.published_at.map(|dt| dt.to_string()),
+            reactions: Reactions::try_from(comment.reactions)?,
+            replies: Replies::try_from(comment.replies)?,
+            upvote_count: i32::try_from(comment.upvote_count)?,
+            url: comment.url,
+        })
+    }
+}
+
+impl From<DiscussionsRepositoryDiscussionsNodesLabels> for Labels {
+    fn from(labels: DiscussionsRepositoryDiscussionsNodesLabels) -> Self {
+        let nodes: Vec<String> = labels
+            .nodes
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(|label| label.name)
+            .collect();
+        Self { nodes }
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodesReactions> for Reactions {
+    type Error = TryFromIntError;
+
+    fn try_from(
+        reactions: DiscussionsRepositoryDiscussionsNodesReactions,
+    ) -> Result<Self, Self::Error> {
+        let nodes = reactions
+            .nodes
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(|reaction| Reaction {
+                content: reaction.content,
+                created_at: reaction.created_at.to_string(),
+            })
+            .collect();
+        Ok(Self {
+            total_count: i32::try_from(reactions.total_count)?,
+            nodes,
+        })
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodesAnswerReplies> for Replies {
+    type Error = TryFromIntError;
+
+    fn try_from(
+        replies: DiscussionsRepositoryDiscussionsNodesAnswerReplies,
+    ) -> Result<Self, Self::Error> {
+        let nodes = replies
+            .nodes
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(|reply| {
+                let author = match reply.author {
+                    Some(DiscussionsRepositoryDiscussionsNodesAnswerRepliesNodesAuthor::User(
+                        author,
+                    )) => author.login,
+                    _ => String::default(),
+                };
+
+                Reply {
+                    body: reply.body,
+                    created_at: reply.created_at.to_string(),
+                    updated_at: reply.updated_at.to_string(),
+                    is_answer: reply.is_answer,
+                    author,
+                }
+            })
+            .collect();
+        Ok(Self {
+            total_count: i32::try_from(replies.total_count)?,
+            nodes,
+        })
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodesCommentsNodesReactions> for Reactions {
+    type Error = TryFromIntError;
+
+    fn try_from(
+        reactions: DiscussionsRepositoryDiscussionsNodesCommentsNodesReactions,
+    ) -> Result<Self, Self::Error> {
+        let nodes = reactions
+            .nodes
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(|reaction| Reaction {
+                content: reaction.content,
+                created_at: reaction.created_at.to_string(),
+            })
+            .collect();
+        Ok(Self {
+            total_count: i32::try_from(reactions.total_count)?,
+            nodes,
+        })
+    }
+}
+
+impl TryFrom<DiscussionsRepositoryDiscussionsNodesCommentsNodesReplies> for Replies {
+    type Error = TryFromIntError;
+
+    fn try_from(
+        replies: DiscussionsRepositoryDiscussionsNodesCommentsNodesReplies,
+    ) -> Result<Self, Self::Error> {
+        let nodes = replies
+            .nodes
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(|reply| {
+                let author = match reply.author {
+                    Some(
+                        DiscussionsRepositoryDiscussionsNodesCommentsNodesRepliesNodesAuthor::User(
+                            author,
+                        ),
+                    ) => author.login,
+                    _ => String::default(),
+                };
+
+                Reply {
+                    body: reply.body,
+                    created_at: reply.created_at.to_string(),
+                    updated_at: reply.updated_at.to_string(),
+                    is_answer: reply.is_answer,
+                    author,
+                }
+            })
+            .collect();
+        Ok(Self {
+            total_count: i32::try_from(replies.total_count)?,
+            nodes,
+        })
+    }
+}

--- a/src/github/discussions.graphql
+++ b/src/github/discussions.graphql
@@ -1,0 +1,135 @@
+query Discussions(
+  $owner: String!
+  $name: String!
+  $first: Int
+  $last: Int
+  $before: String
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    discussions(first: $first, last: $last, before: $before, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        answer {
+          body
+          createdAt
+          updatedAt
+          url
+          # TODO: #181
+          replies(last: 10) {
+            totalCount
+            nodes {
+              body
+              createdAt
+              updatedAt
+              isAnswer
+              author {
+                __typename
+                ... on User {
+                  login
+                }
+              }
+            }
+          }
+          author {
+            __typename
+            ... on User {
+              login
+            }
+          }
+        }
+        answerChosenAt
+        answerChosenBy {
+          __typename
+          ... on User {
+            login
+          }
+        }
+        author {
+          __typename
+          ... on User {
+            login
+          }
+        }
+        body
+        category {
+          name
+        }
+        closed
+        closedAt
+        # TODO: #181
+        comments(last: 100) {
+          totalCount
+          nodes {
+            author {
+              __typename
+              ... on User {
+                login
+              }
+            }
+            body
+            createdAt
+            deletedAt
+            isAnswer
+            isMinimized
+            lastEditedAt
+            publishedAt
+            # TODO: #181
+            reactions(last: 10) {
+              totalCount
+              nodes {
+                content
+                createdAt
+              }
+            }
+            # TODO: #181
+            replies(last: 10) {
+              totalCount
+              nodes {
+                body
+                createdAt
+                updatedAt
+                isAnswer
+                author {
+                  __typename
+                  ... on User {
+                    login
+                  }
+                }
+              }
+            }
+            updatedAt
+            upvoteCount
+            url
+          }
+        }
+        createdAt
+        isAnswered
+        # TODO: #181
+        labels(last: 10) {
+          totalCount
+          nodes {
+            name
+            color
+          }
+        }
+        lastEditedAt
+        number
+        reactions(last: 10) {
+          totalCount
+          nodes {
+            content
+            createdAt
+          }
+        }
+        title
+        updatedAt
+        upvoteCount
+        url
+      }
+    }
+  }
+}

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,3 +1,4 @@
+mod discussion;
 pub(crate) mod issue;
 pub(crate) mod issue_stat;
 pub(crate) mod pull_request;
@@ -12,6 +13,7 @@ use async_graphql::{
 use base64::{engine::general_purpose, Engine as _};
 use jiff::Timestamp;
 
+pub(crate) use self::discussion::Discussion;
 use crate::database::Database;
 
 /// The default page size for connections when neither `first` nor `last` is
@@ -26,6 +28,7 @@ pub(crate) struct Query(
     issue::IssueQuery,
     pull_request::PullRequestQuery,
     issue_stat::IssueStatQuery,
+    discussion::DiscussionQuery,
 );
 
 pub(crate) type Schema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;

--- a/src/graphql/discussion.rs
+++ b/src/graphql/discussion.rs
@@ -1,0 +1,218 @@
+use std::fmt;
+
+use anyhow::Context as AnyhowContext;
+use async_graphql::{
+    connection::{query, Connection, EmptyFields},
+    scalar, Context, Object, Result, SimpleObject,
+};
+
+use crate::{
+    database::{self, Database, DiscussionDbSchema, TryFromKeyValue},
+    github::discussions::ReactionContent,
+};
+
+scalar!(ReactionContent);
+
+#[derive(SimpleObject)]
+pub struct Discussion {
+    owner: String,
+    repo: String,
+    number: i32,
+    title: String,
+    author: String,
+}
+
+impl Discussion {
+    pub fn new(owner: String, repo: String, number: i32, schema: DiscussionDbSchema) -> Self {
+        Self {
+            owner,
+            repo,
+            number,
+            title: schema.title,
+            author: schema.author,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct DiscussionQuery;
+
+#[Object]
+impl DiscussionQuery {
+    async fn discussions(
+        &self,
+        ctx: &Context<'_>,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> Result<Connection<String, Discussion, EmptyFields, EmptyFields>> {
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after, before, first, last| async move {
+                super::load_connection(ctx, Database::discussions, after, before, first, last)
+            },
+        )
+        .await
+    }
+}
+
+impl TryFromKeyValue for Discussion {
+    fn try_from_key_value(key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
+        let (owner, repo, number) = database::parse_key(key)
+            .with_context(|| format!("invalid key in database: {key:02x?}"))?;
+        let discussion_schema = bincode::deserialize::<DiscussionDbSchema>(value)?;
+        let discussion = Discussion::new(owner, repo, number, discussion_schema);
+        Ok(discussion)
+    }
+}
+
+impl fmt::Display for Discussion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}/{}#{}", self.owner, self.repo, self.number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        database::{
+            discussion::{
+                Answer, Category, Comment, Comments, Labels, Reaction, Reactions, Replies, Reply,
+            },
+            DiscussionDbSchema,
+        },
+        github::discussions::ReactionContent,
+        graphql::TestSchema,
+    };
+
+    #[tokio::test]
+    async fn discussion_empty() {
+        let schema = TestSchema::new();
+        let query = r"
+        {
+            discussions {
+                edges {
+                    node {
+                        number
+                    }
+                }
+            }
+        }";
+        let res = schema.execute(query).await;
+        assert_eq!(res.data.to_string(), "{discussions: {edges: []}}");
+    }
+    #[allow(clippy::too_many_lines)]
+    #[tokio::test]
+    async fn discussions_first() {
+        let schema = TestSchema::new();
+        let date = "2025/06/05".to_string();
+        let discussions = vec![DiscussionDbSchema {
+            number: 123,
+            title: "How to use this with API?".to_string(),
+            author: "alice".to_string(),
+            body: "I'm trying to test this API in my project.".to_string(),
+            url: "https://github.com/sample/sample/discussions/123".to_string(),
+            created_at: date.clone(),
+            updated_at: date.clone(),
+            is_answered: true,
+            answer_chosen_at: Some(date.clone()),
+            answer: Some(Answer {
+                body: "You can use the OpenAI API by creating an API key and using the endpoint."
+                    .to_string(),
+                created_at: date.clone(),
+                updated_at: date.clone(),
+                url: "https://github.com/sample/sample/discussions/123#answer".to_string(),
+                author: "bob".to_string(),
+                replies: Replies {
+                    total_count: 1,
+                    nodes: vec![Reply {
+                        body: "Thanks! That helped.".to_string(),
+                        created_at: date.clone(),
+                        updated_at: date.clone(),
+                        is_answer: false,
+                        author: "alice".to_string(),
+                    }],
+                },
+            }),
+            category: Category {
+                name: "Q&A".to_string(),
+            },
+            labels: Some(Labels {
+                nodes: vec!["api".to_string(), "help".to_string()],
+            }),
+            comments: Comments {
+                total_count: 2,
+                nodes: vec![Comment {
+                    body: "Did you check the API docs?".to_string(),
+                    author: "charlie".to_string(),
+                    created_at: date.clone(),
+                    updated_at: date.clone(),
+                    deleted_at: None,
+                    is_answer: false,
+                    is_minimized: false,
+                    last_edited_at: None,
+                    published_at: Some(date.clone()),
+                    reactions: Reactions {
+                        total_count: 2,
+                        nodes: vec![
+                            Reaction {
+                                content: ReactionContent::Other("+1".to_string()),
+                                created_at: date.clone(),
+                            },
+                            Reaction {
+                                content: ReactionContent::Other("heart".to_string()),
+                                created_at: date.clone(),
+                            },
+                        ],
+                    },
+                    replies: Replies {
+                        total_count: 1,
+                        nodes: vec![Reply {
+                            body: "Yes, but I still had some confusion.".to_string(),
+                            created_at: date.clone(),
+                            updated_at: date.clone(),
+                            is_answer: false,
+                            author: "alice".to_string(),
+                        }],
+                    },
+                    upvote_count: 3,
+                    url: "https://github.com/sample/sample/discussions/123#comment-1".to_string(),
+                }],
+            },
+            reactions: Reactions {
+                total_count: 4,
+                nodes: vec![Reaction {
+                    content: ReactionContent::Other("thumbs_up".to_string()),
+                    created_at: date.clone(),
+                }],
+            },
+        }];
+        schema
+            .db
+            .insert_discussions(discussions, "owner", "name")
+            .unwrap();
+
+        let query = r"
+        {
+            discussions(first: 2) {
+                edges {
+                    node {
+                        number
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                }
+            }
+        }";
+        let res = schema.execute(query).await;
+        assert_eq!(
+            res.data.to_string(),
+            "{discussions: {edges: [{node: {number: 123}}], pageInfo: {hasNextPage: false}}}"
+        );
+    }
+}


### PR DESCRIPTION
## Related Issue
- close #171 

## PR Description
GitHub로부터 `Discussion` 데이터를 가져와 저장하는 기능을 구현했습니다.
기존 코드의 구조를 참고하되, 역할에 따라 파일을 분리하여 가독성과 유지보수성을 높였습니다.
현재 `GraphQL` 쿼리는 `Discussion`의 모든 필드를 포함하고 있지 않습니다.

### 파일 역할
- `database/discussion.rs` : DB에 저장될 스키마 구조체 정의
- `graphql/discussion.rs` : GitHub Dashboard에서 제공하는 GraphQL API 응답 구조체 정의