### PR TITLE
Update `issues` GraphQL query and related codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `assignee`, `author`, `repo`(repository name), `begin` and `end` (creation
   date range). The query returns the `openIssueCount` field, indicating the
   number of open issues.
+- Added additional fields to the `issues` GraphQL query, providing detailed information
+  such as comments, labels, related sub-issues, linked pull requests, issue descriptions,
+  timestamps, and project-related metadata.
 
 ### Changed
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -151,7 +151,7 @@ impl<T: TryFromKeyValue> DoubleEndedIterator for Iter<T> {
     }
 }
 
-pub(crate) fn parse_key(key: &[u8]) -> Result<(String, String, i64)> {
+pub(crate) fn parse_key(key: &[u8]) -> Result<(String, String, i32)> {
     let re = Regex::new(r"(?P<owner>\S+)/(?P<name>\S+)#(?P<number>[0-9]+)").expect("valid regex");
     if let Some(caps) = re.captures(
         String::from_utf8(key.to_vec())
@@ -172,7 +172,7 @@ pub(crate) fn parse_key(key: &[u8]) -> Result<(String, String, i64)> {
             .name("number")
             .ok_or_else(|| anyhow!("invalid key"))?
             .as_str()
-            .parse::<i64>()
+            .parse::<i32>()
             .context("invalid key")?;
         Ok((owner, name, number))
     } else {

--- a/src/github/issues.graphql
+++ b/src/github/issues.graphql
@@ -20,15 +20,14 @@ query Issues(
         endCursor
       }
       nodes {
+        id
         number
         title
+        body
         state
+        closedAt
         createdAt
         updatedAt
-        closedAt
-        repository {
-          name
-        }
         author {
           __typename
           ... on User {
@@ -36,9 +35,123 @@ query Issues(
           }
         }
         # TODO: #181
-        assignees(first: 10) {
+        assignees(last: 5) {
           nodes {
             login
+          }
+        }
+        # TODO: #181
+        labels(last: 5) {
+          nodes {
+            name
+          }
+        }
+        # TODO: #181
+        comments(last: 100) {
+          totalCount
+          nodes {
+            author {
+              __typename
+              ... on User {
+                login
+              }
+            }
+            body
+            createdAt
+            id
+            repository {
+              name
+            }
+            updatedAt
+            url
+          }
+        }
+        # TODO: #181
+        projectItems(last: 5) {
+          totalCount
+          nodes {
+            __typename
+            id
+            todoStatus: fieldValueByName(name: "Status") {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+              }
+            }
+            todoPriority: fieldValueByName(name: "Priority") {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+              }
+            }
+            todoSize: fieldValueByName(name: "Size") {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+              }
+            }
+            todoInitiationOption: fieldValueByName(name: "Initiation Options") {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+              }
+            }
+            todoPendingDays: fieldValueByName(name: "Pending days") {
+              __typename
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+              }
+            }
+          }
+        }
+        # TODO: #181
+        subIssues(last: 20) {
+          totalCount
+          nodes {
+            id
+            number
+            title
+            state
+            closedAt
+            createdAt
+            updatedAt
+            author {
+              __typename
+              ... on User {
+                login
+              }
+            }
+            # TODO: #181
+            assignees(last: 5) {
+              nodes {
+                login
+              }
+            }
+          }
+        }
+        parent {
+          id
+          number
+          title
+        }
+        url
+        # TODO: #181
+        closedByPullRequestsReferences(last: 5) {
+          edges {
+            node {
+              number
+              state
+              closedAt
+              createdAt
+              updatedAt
+              author {
+                __typename
+                ... on User {
+                  login
+                }
+              }
+              url
+            }
           }
         }
       }

--- a/src/graphql/issue.rs
+++ b/src/graphql/issue.rs
@@ -5,50 +5,204 @@ use async_graphql::{
     connection::{query, Connection, EmptyFields},
     scalar, Context, Object, Result, SimpleObject,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     database::{self, Database, TryFromKeyValue},
-    github::{issues::IssueState, GitHubIssue},
+    github::{
+        issues::{IssueState, PullRequestState},
+        GitHubIssue,
+    },
     graphql::DateTimeUtc,
 };
 
 scalar!(IssueState);
+scalar!(PullRequestState);
 
 #[derive(SimpleObject)]
 pub(crate) struct Issue {
+    pub(crate) id: String,
     pub(crate) owner: String,
     pub(crate) repo: String,
     pub(crate) number: i32,
     pub(crate) title: String,
+    pub(crate) body: String,
+    pub(crate) state: IssueState,
+    pub(crate) author: String,
+    pub(crate) assignees: Vec<String>,
+    pub(crate) labels: Vec<String>,
+    pub(crate) comments: CommentConnection,
+    pub(crate) project_items: ProjectV2ItemConnection,
+    pub(crate) sub_issues: SubIssueConnection,
+    pub(crate) parent: Option<ParentIssue>,
+    pub(crate) url: String,
+    pub(crate) closed_by_pull_requests: Vec<PullRequestRef>,
+    pub(crate) created_at: DateTimeUtc,
+    pub(crate) updated_at: DateTimeUtc,
+    pub(crate) closed_at: Option<DateTimeUtc>,
+}
+
+#[derive(SimpleObject, Debug, Default)]
+pub(crate) struct CommentConnection {
+    pub(crate) total_count: i32,
+    pub(crate) nodes: Vec<Comment>,
+}
+
+#[derive(SimpleObject, Debug)]
+pub(crate) struct Comment {
+    pub(crate) id: String,
+    pub(crate) author: String,
+    pub(crate) body: String,
+    pub(crate) created_at: DateTimeUtc,
+    pub(crate) updated_at: DateTimeUtc,
+    pub(crate) repository_name: String,
+    pub(crate) url: String,
+}
+
+#[derive(SimpleObject, Debug, Default)]
+pub(crate) struct ProjectV2ItemConnection {
+    pub(crate) total_count: i32,
+    pub(crate) nodes: Vec<ProjectV2Item>,
+}
+
+#[derive(SimpleObject, Debug)]
+pub(crate) struct ProjectV2Item {
+    pub(crate) id: String,
+    pub(crate) todo_status: Option<String>,
+    pub(crate) todo_priority: Option<String>,
+    pub(crate) todo_size: Option<String>,
+    pub(crate) todo_initiation_option: Option<String>,
+    pub(crate) todo_pending_days: Option<f64>,
+}
+
+#[derive(SimpleObject, Debug, Default)]
+pub(crate) struct SubIssueConnection {
+    pub(crate) total_count: i32,
+    pub(crate) nodes: Vec<SubIssue>,
+}
+
+#[derive(SimpleObject, Debug)]
+pub(crate) struct SubIssue {
+    pub(crate) id: String,
+    pub(crate) number: i32,
+    pub(crate) title: String,
+    pub(crate) state: IssueState,
+    pub(crate) author: String,
+    pub(crate) assignees: Vec<String>,
+    pub(crate) created_at: DateTimeUtc,
+    pub(crate) updated_at: DateTimeUtc,
+    pub(crate) closed_at: Option<DateTimeUtc>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Debug)]
+pub(crate) struct ParentIssue {
+    pub(crate) id: String,
+    pub(crate) number: i32,
+    pub(crate) title: String,
+}
+
+#[derive(SimpleObject, Debug)]
+pub(crate) struct PullRequestRef {
+    pub(crate) number: i32,
+    pub(crate) state: PullRequestState,
     pub(crate) author: String,
     pub(crate) created_at: DateTimeUtc,
-    pub(crate) state: IssueState,
-    pub(crate) assignees: Vec<String>,
+    pub(crate) updated_at: DateTimeUtc,
+    pub(crate) closed_at: Option<DateTimeUtc>,
+    pub(crate) url: String,
 }
 
 impl TryFromKeyValue for Issue {
     fn try_from_key_value(key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
         let (owner, repo, number) = database::parse_key(key)
             .with_context(|| format!("invalid key in database: {key:02x?}"))?;
-        let GitHubIssue {
-            title,
-            author,
-            created_at,
-            state,
-            assignees,
-            ..
-        } = bincode::deserialize::<GitHubIssue>(value)?;
-        let issue = Issue {
-            title,
-            author,
+        let issue: GitHubIssue = bincode::deserialize(value)?;
+        Ok(Issue {
+            id: issue.id,
             owner,
             repo,
-            number: i32::try_from(number).unwrap_or(i32::MAX),
-            created_at: DateTimeUtc(created_at),
-            state,
-            assignees,
-        };
-        Ok(issue)
+            number,
+            title: issue.title,
+            body: issue.body,
+            state: issue.state,
+            author: issue.author,
+            assignees: issue.assignees,
+            labels: issue.labels,
+            comments: CommentConnection {
+                total_count: issue.comments.total_count,
+                nodes: issue
+                    .comments
+                    .nodes
+                    .into_iter()
+                    .map(|comment| Comment {
+                        id: comment.id,
+                        author: comment.author,
+                        body: comment.body,
+                        repository_name: comment.repository_name,
+                        url: comment.url,
+                        created_at: DateTimeUtc(comment.created_at),
+                        updated_at: DateTimeUtc(comment.updated_at),
+                    })
+                    .collect(),
+            },
+            project_items: ProjectV2ItemConnection {
+                total_count: issue.project_items.total_count,
+                nodes: issue
+                    .project_items
+                    .nodes
+                    .into_iter()
+                    .map(|item| ProjectV2Item {
+                        id: item.id,
+                        todo_status: item.todo_status,
+                        todo_priority: item.todo_priority,
+                        todo_size: item.todo_size,
+                        todo_initiation_option: item.todo_initiation_option,
+                        todo_pending_days: item.todo_pending_days,
+                    })
+                    .collect(),
+            },
+            sub_issues: SubIssueConnection {
+                total_count: issue.sub_issues.total_count,
+                nodes: issue
+                    .sub_issues
+                    .nodes
+                    .into_iter()
+                    .map(|sub| SubIssue {
+                        id: sub.id,
+                        number: sub.number,
+                        title: sub.title,
+                        state: sub.state,
+                        author: sub.author,
+                        assignees: sub.assignees,
+                        created_at: DateTimeUtc(sub.created_at),
+                        updated_at: DateTimeUtc(sub.updated_at),
+                        closed_at: sub.closed_at.map(DateTimeUtc),
+                    })
+                    .collect(),
+            },
+            parent: issue.parent.map(|p| ParentIssue {
+                id: p.id,
+                number: p.number,
+                title: p.title,
+            }),
+            url: issue.url,
+            closed_by_pull_requests: issue
+                .closed_by_pull_requests
+                .into_iter()
+                .map(|pr| PullRequestRef {
+                    number: pr.number,
+                    state: pr.state,
+                    author: pr.author,
+                    url: pr.url,
+                    created_at: DateTimeUtc(pr.created_at),
+                    updated_at: DateTimeUtc(pr.updated_at),
+                    closed_at: pr.closed_at.map(DateTimeUtc),
+                })
+                .collect(),
+            created_at: DateTimeUtc(issue.created_at),
+            updated_at: DateTimeUtc(issue.updated_at),
+            closed_at: issue.closed_at.map(DateTimeUtc),
+        })
     }
 }
 
@@ -91,7 +245,7 @@ mod tests {
     fn create_issues(n: usize) -> Vec<GitHubIssue> {
         (1..=n)
             .map(|i| GitHubIssue {
-                number: i64::try_from(i).unwrap(),
+                number: i.try_into().unwrap(),
                 ..Default::default()
             })
             .collect()

--- a/src/graphql/issue_stat.rs
+++ b/src/graphql/issue_stat.rs
@@ -85,7 +85,7 @@ mod tests {
     fn create_issues(n: usize) -> Vec<GitHubIssue> {
         (0..n)
             .map(|i| GitHubIssue {
-                number: i64::try_from(i).unwrap(),
+                number: i.try_into().unwrap(),
                 ..Default::default()
             })
             .collect()

--- a/src/graphql/pull_request.rs
+++ b/src/graphql/pull_request.rs
@@ -25,12 +25,12 @@ impl TryFromKeyValue for PullRequest {
         let deserialized = bincode::deserialize::<(String, Vec<String>, Vec<String>)>(value)?;
         let (title, assignees, reviewers) = deserialized;
         let pr = PullRequest {
+            owner,
+            repo,
+            number,
             title,
             assignees,
             reviewers,
-            owner,
-            repo,
-            number: i32::try_from(number).unwrap_or(i32::MAX),
         };
         Ok(pr)
     }


### PR DESCRIPTION
- Added new fields (specified in #169) to the GraphQL query.
- Restored previously commented-out project-related fields.
- Explicitly mapped GraphQL custom scalar `URI` to Rust.
- Made `Issue` struct support serialization/deserialization to enable storing/retrieving from the database.
- Updated `GitHubIssue` struct to align with the `Issue` struct, and adjusted related functions accordingly.

Close: #169