### PR TITLE
Add new fields to `PullRequests` query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   timestamps, and project-related metadata.
 - Exposed a new `discussions` query in the server’s GraphQL API to query the
   stored discussion data.
+- Added new fields to the `PullRequests` GraphQL query and corresponding fields to
+  the `api::pull_request::PullRequest` struct.
 - Added a new GraphQL API: `discussionStat` query, allowing users to filter
   discussions by `author`, `repo` (repository name), `begin`, and `end`
   (creation date range). The query returns the `totalCount` field, indicating

--- a/src/api/pull_request.rs
+++ b/src/api/pull_request.rs
@@ -3,45 +3,217 @@ use std::fmt;
 use anyhow::Context as AnyhowContext;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
-    Context, Object, Result, SimpleObject,
+    scalar, Context, Object, Result, SimpleObject,
 };
+use jiff::Timestamp;
 
 use crate::{
-    api,
-    database::{self, Database, TryFromKeyValue},
+    api::{self, DateTimeUtc},
+    database::{Database, TryFromKeyValue},
+    outbound::{
+        GitHubCommitConnection, GitHubPRCommentConnection, GitHubPullRequestNode,
+        GitHubReviewConnection, PRPullRequestState as PullRequestState, PullRequestReviewState,
+        RepositoryNode,
+    },
 };
+scalar!(PullRequestState);
+scalar!(PullRequestReviewState);
+
+#[derive(SimpleObject, Debug)]
+pub(crate) struct PullRequestComment {
+    pub(crate) body: String,
+    pub(crate) created_at: DateTimeUtc,
+    pub(crate) updated_at: DateTimeUtc,
+    pub(crate) author: String,
+}
+
+#[derive(SimpleObject)]
+pub(crate) struct Review {
+    pub(crate) author: String,
+    pub(crate) state: PullRequestReviewState,
+    pub(crate) body: Option<String>,
+    pub(crate) url: String,
+    pub(crate) created_at: DateTimeUtc,
+    pub(crate) published_at: Option<DateTimeUtc>,
+    pub(crate) submitted_at: DateTimeUtc,
+    pub(crate) is_minimized: bool,
+    pub(crate) comments: Vec<PullRequestComment>,
+}
+
+#[derive(SimpleObject)]
+pub(crate) struct CommitInfo {
+    pub(crate) additions: i32,
+    pub(crate) deletions: i32,
+    pub(crate) message: String,
+    pub(crate) message_body: Option<String>,
+    pub(crate) author: String,
+    pub(crate) changed_files_if_available: Option<i32>,
+    pub(crate) committed_date: DateTimeUtc,
+    pub(crate) committer: String,
+}
 
 #[derive(SimpleObject)]
 pub(crate) struct PullRequest {
+    pub(crate) id: String,
     pub(crate) owner: String,
     pub(crate) repo: String,
     pub(crate) number: i32,
     pub(crate) title: String,
+    pub(crate) body: Option<String>,
+    pub(crate) state: PullRequestState,
     pub(crate) assignees: Vec<String>,
-    pub(crate) reviewers: Vec<String>,
+    pub(crate) created_at: DateTimeUtc,
+    pub(crate) updated_at: DateTimeUtc,
+    pub(crate) closed_at: Option<DateTimeUtc>,
+    pub(crate) merged_at: Option<DateTimeUtc>,
+    pub(crate) author: String,
+    pub(crate) additions: i32,
+    pub(crate) deletions: i32,
+    pub(crate) url: String,
+    pub(crate) labels: Vec<String>,
+    pub(crate) comments_count: i32,
+    pub(crate) comments: Vec<PullRequestComment>,
+    pub(crate) review_decision: Option<PullRequestReviewState>,
+    pub(crate) review_requests: Vec<String>,
+    pub(crate) reviews_count: i32,
+    pub(crate) reviews: Vec<Review>,
+    pub(crate) commits_count: i32,
+    pub(crate) commits: Vec<CommitInfo>,
 }
 
 impl TryFromKeyValue for PullRequest {
-    fn try_from_key_value(key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
-        let (owner, repo, number) = database::parse_key(key)
-            .with_context(|| format!("invalid key in database: {key:02x?}"))?;
-        let deserialized = bincode::deserialize::<(String, Vec<String>, Vec<String>)>(value)?;
-        let (title, assignees, reviewers) = deserialized;
-        let pr = PullRequest {
-            owner,
-            repo,
-            number,
-            title,
-            assignees,
-            reviewers,
-        };
-        Ok(pr)
+    #[allow(clippy::too_many_lines)]
+    fn try_from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
+        let gh: GitHubPullRequestNode = bincode::deserialize(value)
+            .with_context(|| format!("Deserialization failed for value: {value:?}"))?;
+        let labels = gh.labels;
+        let comments = gh
+            .comments
+            .nodes
+            .into_iter()
+            .map(|c| PullRequestComment {
+                body: c.body,
+                created_at: DateTimeUtc(c.created_at),
+                updated_at: DateTimeUtc(c.updated_at),
+                author: c.author,
+            })
+            .collect();
+        let reviews = gh
+            .reviews
+            .nodes
+            .into_iter()
+            .map(|r| Review {
+                author: r.author,
+                state: r.state,
+                body: r.body,
+                url: r.url,
+                created_at: DateTimeUtc(r.created_at),
+                published_at: r.published_at.map(DateTimeUtc),
+                submitted_at: DateTimeUtc(r.submitted_at),
+                is_minimized: r.is_minimized,
+                comments: r
+                    .comments
+                    .nodes
+                    .into_iter()
+                    .map(|c| PullRequestComment {
+                        body: c.body,
+                        created_at: DateTimeUtc(c.created_at),
+                        updated_at: DateTimeUtc(c.updated_at),
+                        author: c.author,
+                    })
+                    .collect(),
+            })
+            .collect();
+        let commits = gh
+            .commits
+            .nodes
+            .into_iter()
+            .map(|c| CommitInfo {
+                additions: c.additions,
+                deletions: c.deletions,
+                message: c.message,
+                message_body: c.message_body,
+                author: c.author,
+                changed_files_if_available: c.changed_files_if_available,
+                committed_date: DateTimeUtc(c.committed_date),
+                committer: c.committer,
+            })
+            .collect();
+
+        Ok(PullRequest {
+            id: gh.id,
+            owner: gh.repository.owner,
+            repo: gh.repository.name,
+            number: gh.number,
+            title: gh.title,
+            body: gh.body,
+            state: gh.state,
+            created_at: DateTimeUtc(gh.created_at),
+            updated_at: DateTimeUtc(gh.updated_at),
+            closed_at: gh.closed_at.map(DateTimeUtc),
+            merged_at: gh.merged_at.map(DateTimeUtc),
+            author: gh.author,
+            additions: gh.additions,
+            deletions: gh.deletions,
+            url: gh.url,
+            labels,
+            comments_count: gh.comments.total_count,
+            comments,
+            review_decision: gh.review_decision,
+            assignees: gh.assignees,
+            review_requests: gh.review_requests,
+            reviews_count: gh.reviews.total_count,
+            reviews,
+            commits_count: gh.commits.total_count,
+            commits,
+        })
     }
 }
 
 impl fmt::Display for PullRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}/{}#{}", self.owner, self.repo, self.number)
+    }
+}
+
+impl Default for GitHubPullRequestNode {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            number: 0,
+            title: String::new(),
+            body: None,
+            state: PullRequestState::OPEN,
+            created_at: Timestamp::now(),
+            updated_at: Timestamp::now(),
+            closed_at: None,
+            merged_at: None,
+            author: String::new(),
+            additions: 0,
+            deletions: 0,
+            url: String::new(),
+            repository: RepositoryNode {
+                owner: String::new(),
+                name: String::new(),
+            },
+
+            labels: vec![],
+            comments: GitHubPRCommentConnection {
+                total_count: 0,
+                nodes: vec![],
+            },
+            review_decision: None,
+            assignees: vec![],
+            review_requests: vec![],
+            reviews: GitHubReviewConnection {
+                total_count: 0,
+                nodes: vec![],
+            },
+            commits: GitHubCommitConnection {
+                total_count: 0,
+                nodes: vec![],
+            },
+        }
     }
 }
 
@@ -73,7 +245,11 @@ impl PullRequestQuery {
 
 #[cfg(test)]
 mod tests {
-    use crate::{api::TestSchema, outbound::GitHubPullRequests};
+    use crate::api::TestSchema;
+    use crate::outbound::{
+        GitHubCommitConnection, GitHubPRCommentConnection, GitHubPullRequestNode,
+        GitHubReviewConnection, PRPullRequestState, RepositoryNode,
+    };
 
     #[tokio::test]
     async fn pull_requests_empty() {
@@ -87,26 +263,86 @@ mod tests {
                     }
                 }
             }
-        }";
+        }
+        ";
         let res = schema.execute(query).await;
         assert_eq!(res.data.to_string(), "{pullRequests: {edges: []}}");
     }
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn pull_requests_first() {
         let schema = TestSchema::new();
         let pull_requests = vec![
-            GitHubPullRequests {
+            GitHubPullRequestNode {
+                id: "pr-1".to_string(),
                 number: 1,
                 title: "pull request 1".to_string(),
+                body: Some(String::new()),
+                state: PRPullRequestState::OPEN,
+                created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                closed_at: None,
+                merged_at: None,
+                author: "author 1".to_string(),
+                additions: 0,
+                deletions: 0,
+                url: String::new(),
+                repository: RepositoryNode {
+                    owner: "owner".to_string(),
+                    name: "repo".to_string(),
+                },
+                labels: vec![],
+                comments: GitHubPRCommentConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                review_decision: None,
                 assignees: vec!["assignee 1".to_string()],
-                reviewers: vec!["reviewer 1".to_string()],
+                review_requests: vec!["reviewer 1".to_string()],
+                reviews: GitHubReviewConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                commits: GitHubCommitConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
             },
-            GitHubPullRequests {
+            GitHubPullRequestNode {
+                id: "pr-2".to_string(),
                 number: 2,
                 title: "pull request 2".to_string(),
+                body: Some(String::new()),
+                state: PRPullRequestState::OPEN,
+                created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                closed_at: None,
+                merged_at: None,
+                author: "author 2".to_string(),
+                additions: 0,
+                deletions: 0,
+                url: String::new(),
+                repository: RepositoryNode {
+                    owner: "owner".to_string(),
+                    name: "repo".to_string(),
+                },
+                labels: vec![],
+                comments: GitHubPRCommentConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                review_decision: None,
                 assignees: vec!["assignee 2".to_string()],
-                reviewers: vec!["reviewer 2".to_string()],
+                review_requests: vec!["reviewer 2".to_string()],
+                reviews: GitHubReviewConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                commits: GitHubCommitConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
             },
         ];
         schema
@@ -126,7 +362,8 @@ mod tests {
                     hasNextPage
                 }
             }
-        }";
+        }
+        ";
         let res = schema.execute(query).await;
         assert_eq!(
             res.data.to_string(),
@@ -140,7 +377,8 @@ mod tests {
                     hasNextPage
                 }
             }
-        }";
+        }
+        ";
         let res = schema.execute(query).await;
         assert_eq!(
             res.data.to_string(),
@@ -149,20 +387,79 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn pull_requests_last() {
         let schema = TestSchema::new();
         let pull_requests = vec![
-            GitHubPullRequests {
+            GitHubPullRequestNode {
+                id: "pr-1".to_string(),
                 number: 1,
                 title: "pull request 1".to_string(),
+                body: Some(String::new()),
+                state: PRPullRequestState::OPEN,
+                created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                closed_at: None,
+                merged_at: None,
+                author: "author 1".to_string(),
+                additions: 0,
+                deletions: 0,
+                url: String::new(),
+                repository: RepositoryNode {
+                    owner: "owner".to_string(),
+                    name: "repo".to_string(),
+                },
+                labels: vec![],
+                comments: GitHubPRCommentConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                review_decision: None,
                 assignees: vec!["assignee 1".to_string()],
-                reviewers: vec!["reviewer 1".to_string()],
+                review_requests: vec!["reviewer 1".to_string()],
+                reviews: GitHubReviewConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                commits: GitHubCommitConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
             },
-            GitHubPullRequests {
+            GitHubPullRequestNode {
+                id: "pr-2".to_string(),
                 number: 2,
                 title: "pull request 2".to_string(),
+                body: Some(String::new()),
+                state: PRPullRequestState::OPEN,
+                created_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                updated_at: "2024-01-01T00:00:00Z".parse().unwrap(),
+                closed_at: None,
+                merged_at: None,
+                author: "author 2".to_string(),
+                additions: 0,
+                deletions: 0,
+                url: String::new(),
+                repository: RepositoryNode {
+                    owner: "owner".to_string(),
+                    name: "repo".to_string(),
+                },
+                labels: vec![],
+                comments: GitHubPRCommentConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                review_decision: None,
                 assignees: vec!["assignee 2".to_string()],
-                reviewers: vec!["reviewer 2".to_string()],
+                review_requests: vec!["reviewer 2".to_string()],
+                reviews: GitHubReviewConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
+                commits: GitHubCommitConnection {
+                    total_count: 0,
+                    nodes: vec![],
+                },
             },
         ];
         schema
@@ -182,7 +479,8 @@ mod tests {
                     hasPreviousPage
                 }
             }
-        }";
+        }
+        ";
         let res = schema.execute(query).await;
         assert_eq!(
             res.data.to_string(),
@@ -196,11 +494,20 @@ mod tests {
                     hasPreviousPage
                 }
             }
-        }";
+        }
+        ";
         let res = schema.execute(query).await;
         assert_eq!(
             res.data.to_string(),
             "{pullRequests: {pageInfo: {hasPreviousPage: false}}}"
         );
+    }
+
+    #[tokio::test]
+    async fn default_github_pull_request_node() {
+        let pr = GitHubPullRequestNode::default();
+        assert_eq!(pr.number, 0);
+        assert!(pr.id.is_empty());
+        assert!(pr.repository.owner.is_empty());
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -11,7 +11,7 @@ pub(crate) use discussion::DiscussionDbSchema;
 
 use crate::{
     api::{issue::Issue, pull_request::PullRequest},
-    outbound::{GitHubIssue, GitHubPullRequests},
+    outbound::{GitHubIssue, GitHubPullRequestNode},
 };
 
 const GLOBAL_PARTITION_NAME: &str = "global";
@@ -101,17 +101,13 @@ impl Database {
 
     pub(crate) fn insert_pull_requests(
         &self,
-        resp: Vec<GitHubPullRequests>,
+        resp: Vec<GitHubPullRequestNode>,
         owner: &str,
         name: &str,
     ) -> Result<()> {
         for item in resp {
             let keystr: String = format!("{owner}/{name}#{}", item.number);
-            Database::insert(
-                &keystr,
-                (&item.title, &item.assignees, &item.reviewers),
-                &self.pull_request_partition,
-            )?;
+            Database::insert(&keystr, item, &self.pull_request_partition)?;
         }
         Ok(())
     }

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use tokio::time;
 use tracing::error;
 
+pub use self::pull_requests::{PullRequestReviewState, PullRequestState as PRPullRequestState};
+use crate::database::DiscussionDbSchema;
 use crate::{
     database::Database,
     outbound::{
@@ -23,11 +25,15 @@ use crate::{
             IssuesRepositoryIssuesNodesSubIssuesNodesAuthor::User as SubIssueAuthor,
             PullRequestState,
         },
-        pull_requests::PullRequestsRepositoryPullRequestsNodesReviewRequestsNodesRequestedReviewer::User,
+        pull_requests::{
+            PullRequestReviewDecision,
+            PullRequestsRepositoryPullRequestsNodesAuthor::User as PullRequestAuthorUser,
+            PullRequestsRepositoryPullRequestsNodesCommentsNodesAuthor as PRCommentAuthor,
+            PullRequestsRepositoryPullRequestsNodesReviewRequestsNodesRequestedReviewer::User as PRReviewRequestedUser,
+        },
     },
     settings::Repository as RepoInfo,
 };
-use crate::database::DiscussionDbSchema;
 
 const GITHUB_FETCH_SIZE: i64 = 10;
 const GITHUB_URL: &str = "https://api.github.com/graphql";
@@ -50,7 +56,8 @@ pub(crate) struct Issues;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/outbound/graphql/schema.graphql",
-    query_path = "src/outbound/graphql/pull_requests.graphql"
+    query_path = "src/outbound/graphql/pull_requests.graphql",
+    response_derives = "Debug, Clone"
 )]
 struct PullRequests;
 
@@ -79,7 +86,7 @@ pub(super) struct GitHubIssue {
     pub(super) state: IssueState,
     pub(super) assignees: Vec<String>,
     pub(super) labels: Vec<String>,
-    pub(super) comments: GitHubCommentConnection,
+    pub(super) comments: GitHubIssueCommentConnection,
     pub(super) project_items: GitHubProjectV2ItemConnection,
     pub(super) sub_issues: GitHubSubIssueConnection,
     pub(super) parent: Option<GitHubParentIssue>,
@@ -91,13 +98,13 @@ pub(super) struct GitHubIssue {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
-pub(crate) struct GitHubCommentConnection {
+pub(crate) struct GitHubIssueCommentConnection {
     pub(crate) total_count: i32,
-    pub(crate) nodes: Vec<GitHubComment>,
+    pub(crate) nodes: Vec<GitHubIssueComment>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub(crate) struct GitHubComment {
+pub(crate) struct GitHubIssueComment {
     pub(crate) id: String,
     pub(crate) author: String,
     pub(crate) body: String,
@@ -105,6 +112,22 @@ pub(crate) struct GitHubComment {
     pub(crate) updated_at: Timestamp,
     pub(crate) repository_name: String,
     pub(crate) url: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct GitHubPRComment {
+    pub(crate) author: String,
+    pub(crate) body: String,
+    pub(crate) created_at: Timestamp,
+    pub(crate) updated_at: Timestamp,
+    pub(crate) repository_name: String,
+    pub(crate) url: String,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct GitHubPRCommentConnection {
+    pub(crate) total_count: i32,
+    pub(crate) nodes: Vec<GitHubPRComment>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -160,12 +183,71 @@ pub(crate) struct GitHubPullRequestRef {
     pub(crate) url: String,
 }
 
-#[derive(Debug)]
-pub(super) struct GitHubPullRequests {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct CommitInner {
+    pub(super) additions: i32,
+    pub(super) deletions: i32,
+    pub(super) message: String,
+    pub(super) message_body: Option<String>,
+    pub(super) author: String,
+    pub(super) changed_files_if_available: Option<i32>,
+    pub(super) committed_date: DateTime,
+    pub(super) committer: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct RepositoryNode {
+    pub(super) owner: String,
+    pub(super) name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ReviewNode {
+    pub(super) author: String,
+    pub(super) state: PullRequestReviewState,
+    pub(super) body: Option<String>,
+    pub(super) url: String,
+    pub(super) created_at: DateTime,
+    pub(super) published_at: Option<DateTime>,
+    pub(super) submitted_at: DateTime,
+    pub(super) is_minimized: bool,
+    pub(super) comments: GitHubPRCommentConnection,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct GitHubCommitConnection {
+    pub(super) total_count: i32,
+    pub(super) nodes: Vec<CommitInner>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct GitHubReviewConnection {
+    pub(super) total_count: i32,
+    pub(super) nodes: Vec<ReviewNode>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct GitHubPullRequestNode {
+    pub(super) id: String,
     pub(super) number: i32,
     pub(super) title: String,
+    pub(super) body: Option<String>,
+    pub(super) state: PRPullRequestState,
+    pub(super) created_at: DateTime,
+    pub(super) updated_at: DateTime,
+    pub(super) closed_at: Option<DateTime>,
+    pub(super) merged_at: Option<DateTime>,
+    pub(super) author: String,
+    pub(super) additions: i32,
+    pub(super) deletions: i32,
+    pub(super) url: String,
+    pub(super) repository: RepositoryNode,
+    pub(super) labels: Vec<String>,
+    pub(super) comments: GitHubPRCommentConnection,
+    pub(super) review_decision: Option<PullRequestReviewState>,
     pub(super) assignees: Vec<String>,
-    pub(super) reviewers: Vec<String>,
+    pub(super) review_requests: Vec<String>,
+    pub(super) reviews: GitHubReviewConnection,
+    pub(super) commits: GitHubCommitConnection,
 }
 
 pub(super) async fn fetch_periodically(
@@ -305,7 +387,7 @@ async fn send_github_issue_query(
                             .flatten()
                             .map(|node| node.name)
                             .collect(),
-                        comments: GitHubCommentConnection {
+                        comments: GitHubIssueCommentConnection {
                             total_count: issue.comments.total_count.try_into().unwrap_or_default(),
                             nodes: issue
                                 .comments
@@ -313,7 +395,7 @@ async fn send_github_issue_query(
                                 .unwrap_or_default()
                                 .into_iter()
                                 .flatten()
-                                .map(|comment| GitHubComment {
+                                .map(|comment| GitHubIssueComment {
                                     author: match comment.author {
                                         Some(IssueCommentsAuthor(u)) => u.login,
                                         _ => String::new(),
@@ -460,15 +542,14 @@ async fn send_github_issue_query(
     }
     Ok(total_issue)
 }
-
+#[allow(clippy::too_many_lines)]
 async fn send_github_pr_query(
     owner: &str,
     name: &str,
     token: &str,
-) -> Result<Vec<Vec<GitHubPullRequests>>> {
+) -> Result<Vec<Vec<GitHubPullRequestNode>>> {
     let mut total_prs = Vec::new();
     let mut end_cur: Option<String> = None;
-    let mut prs: Vec<GitHubPullRequests> = Vec::new();
     loop {
         let var = pull_requests::Variables {
             owner: owner.to_string(),
@@ -476,40 +557,178 @@ async fn send_github_pr_query(
             first: Some(GITHUB_FETCH_SIZE),
             last: None,
             before: None,
-            after: end_cur,
+            after: end_cur.take(),
         };
 
         let resp_body: GraphQlResponse<pull_requests::ResponseData> =
             send_query::<PullRequests>(token, var).await?.json().await?;
         if let Some(data) = resp_body.data {
             if let Some(repository) = data.repository {
-                if let Some(nodes) = repository.pull_requests.nodes.as_ref() {
-                    for pr in nodes.iter().flatten() {
-                        let mut assignees: Vec<String> = Vec::new();
-                        let mut reviewers: Vec<String> = Vec::new();
-
-                        if let Some(assignees_nodes) = pr.assignees.nodes.as_ref() {
-                            for pr_assignees in assignees_nodes.iter().flatten() {
-                                assignees.push(pr_assignees.login.clone());
+                if let Some(nodes) = repository.pull_requests.nodes {
+                    let mut prs = Vec::new();
+                    for pr in nodes.into_iter().flatten() {
+                        let mut assignees_list = Vec::new();
+                        if let Some(ass_nodes) = pr.assignees.nodes {
+                            for node in ass_nodes.into_iter().flatten() {
+                                assignees_list.push(node.login);
                             }
                         }
-                        if let Some(reviewers_nodes) =
-                            pr.review_requests.as_ref().and_then(|r| r.nodes.as_ref())
-                        {
-                            for pr_reviewers in reviewers_nodes.iter().flatten() {
-                                if let Some(User(on_user)) =
-                                    pr_reviewers.requested_reviewer.as_ref()
-                                {
-                                    reviewers.push(on_user.login.clone());
+                        let mut rr_nodes = Vec::new();
+                        if let Some(req_conn) = pr.review_requests {
+                            if let Some(req_nodes) = req_conn.nodes {
+                                for rr in req_nodes.into_iter().flatten() {
+                                    if let Some(PRReviewRequestedUser(user_node)) =
+                                        rr.requested_reviewer
+                                    {
+                                        rr_nodes.push(user_node.login);
+                                    }
                                 }
                             }
                         }
-
-                        prs.push(GitHubPullRequests {
+                        prs.push(GitHubPullRequestNode {
+                            id: pr.id,
                             number: pr.number.try_into().unwrap_or_default(),
-                            title: pr.title.to_string(),
-                            assignees,
-                            reviewers,
+                            title: pr.title,
+                            body: Some(pr.body),
+                            state: pr.state,
+                            created_at: pr.created_at,
+                            updated_at: pr.updated_at,
+                            closed_at: pr.closed_at,
+                            merged_at: pr.merged_at,
+                            author: match pr.author {
+                            Some(PullRequestAuthorUser(user)) => user.login,
+                            _ => String::new(),
+                        },
+                            additions: pr.additions.try_into().unwrap_or_default(),
+                            deletions: pr.deletions.try_into().unwrap_or_default(),
+                            url: pr.url,
+                            repository: RepositoryNode {
+                                owner: pr.repository.owner.login,
+                                name: pr.repository.name.clone(),
+                            },
+                            labels: pr
+                                .labels
+                                .as_ref()
+                                .and_then(|conn| conn.nodes.as_ref())
+                                .map(|nodes| {
+                                    nodes
+                                        .iter()
+                                        .filter_map(|n| n.as_ref().map(|node| node.name.clone()))
+                                        .collect::<Vec<String>>()
+                                })
+                                .unwrap_or_default(),
+                            comments: GitHubPRCommentConnection {
+                                total_count: pr.comments.total_count.try_into().unwrap_or_default(),
+                                nodes: pr
+                                    .comments
+                                    .nodes
+                                    .as_ref()
+                                    .into_iter()
+                                    .flatten()
+                                    .filter_map(|n| n.as_ref())
+                                    .map(|node| GitHubPRComment {
+                                        author: match &node.author {
+                                            Some(PRCommentAuthor::User(u)) => u.login.clone(),
+                                            _ => String::new(),
+                                        },
+                                        body: node.body.clone(),
+                                        created_at: node.created_at,
+                                        updated_at: node.updated_at,
+                                        repository_name: pr.repository.name.clone(),
+                                        url: String::new(),
+                                    })
+                                    .collect(),
+                            },
+
+                            review_decision: pr.review_decision.and_then(|d| match d {
+                                PullRequestReviewDecision::APPROVED => Some(PullRequestReviewState::APPROVED),
+                                PullRequestReviewDecision::CHANGES_REQUESTED => Some(PullRequestReviewState::CHANGES_REQUESTED),
+                                PullRequestReviewDecision::REVIEW_REQUIRED => Some(PullRequestReviewState::PENDING),
+                                PullRequestReviewDecision::Other(_) => None,
+                            }),
+                            assignees: assignees_list,
+                            review_requests: rr_nodes,
+                            reviews: GitHubReviewConnection {
+                                total_count: pr
+                                    .reviews
+                                    .as_ref()
+                                    .map(|r| r.total_count.try_into().unwrap_or_default())
+                                    .unwrap_or_default(),
+                                nodes: pr
+                                    .reviews
+                                    .as_ref()
+                                    .and_then(|r| r.nodes.as_ref())
+                                    .map(|nodes| {
+                                        nodes
+                                            .iter()
+                                            .filter_map(|n| n.as_ref())
+                                            .map(|node| ReviewNode {
+                                                author: node.author.as_ref().and_then(|a| match a {
+                                                    pull_requests::PullRequestsRepositoryPullRequestsNodesReviewsNodesAuthor::User(u) => Some(u.login.clone()),
+                                                    _ => None,
+                                                }).unwrap_or_default(),
+                                                state: node.state.clone(),
+                                                body: Some(node.body.clone()),
+                                                url: node.url.clone(),
+                                                created_at: node.created_at,
+                                                published_at: node.published_at,
+                                                submitted_at: node.submitted_at.unwrap_or_else(Timestamp::now),
+                                                is_minimized: node.is_minimized,
+                                                comments: GitHubPRCommentConnection {
+                                                    total_count: node.comments.total_count.try_into().unwrap_or_default(),
+                                                    nodes: vec![],
+                                                },
+                                            })
+                                            .collect()
+                                    })
+                                    .unwrap_or_default(),
+                            },
+
+
+                            commits: GitHubCommitConnection {
+                                total_count: pr
+                                    .commits
+                                    .total_count
+                                    .try_into()
+                                    .unwrap_or_default(),
+                                nodes: pr
+                                    .commits
+                                    .nodes
+                                    .as_ref()
+                                    .map_or(vec![], |nodes| {
+                                        nodes
+                                            .iter()
+                                            .filter_map(|n| n.as_ref())
+                                            .map(|node| {
+                                                let commit = &node.commit;
+                                                CommitInner {
+                                                    additions: commit.additions.try_into().unwrap_or_default(),
+                                                    deletions: commit.deletions.try_into().unwrap_or_default(),
+                                                    message: commit.message.clone(),
+                                                    message_body: Some(commit.message_body.clone()),
+                                                    author: commit
+                                                        .author
+                                                        .as_ref()
+                                                        .and_then(|a| a.user.as_ref()).map(|u| u.login.clone())
+                                                        .unwrap_or_default(),
+                                                    changed_files_if_available: commit
+                                                        .changed_files_if_available
+                                                        .and_then(|v| v.try_into().ok()),
+                                                    committed_date: commit.committed_date,
+                                                    committer: commit
+                                                        .committer
+                                                        .as_ref()
+                                                        .and_then(|c| c.user.as_ref())
+                                                        .map(|user| user.login.clone())
+                                                        .unwrap_or_default(),
+
+                                                }
+                                            })
+                                            .collect()
+                                    }),
+                            }
+
+
                         });
                     }
                     if !repository.pull_requests.page_info.has_next_page {

--- a/src/outbound/graphql/pull_requests.graphql
+++ b/src/outbound/graphql/pull_requests.graphql
@@ -1,24 +1,136 @@
-query PullRequests($owner: String!, $name:String!, $first:Int, $last:Int, $before:String, $after:String) {
-  repository(owner: $owner name: $name) {
-    pullRequests(first: $first last: $last before: $before after: $after) {
+query PullRequests(
+  $owner: String!
+  $name: String!
+  $first: Int
+  $last: Int
+  $before: String
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: $first, last: $last, before: $before, after: $after) {
       pageInfo {
-        hasNextPage,
-        endCursor,
+        hasNextPage
+        endCursor
       }
       nodes {
-        number,
-        title,
+        id
+        number
+        title
+        body
+        state
+        createdAt
+        updatedAt
+        closedAt
+        mergedAt
+        author {
+          __typename
+          ... on User {
+            login
+          }
+        }
+        additions
+        deletions
+        url
+        repository {
+          owner {
+            __typename
+            login
+          }
+          name
+        }
+        # TODO: #181
+        labels(last: 5) {
+          nodes {
+            name
+          }
+        }
+        # TODO: #181
+        comments(last: 100) {
+          totalCount
+          nodes {
+            body
+            createdAt
+            updatedAt
+            author {
+              __typename
+              ... on User {
+                login
+              }
+            }
+          }
+        }
+        reviewDecision
+        # TODO: #181
         assignees(last: 15) {
           nodes {
             login
           }
-        },
-        reviewRequests(first: 10) {
+        }
+        # TODO: #181
+        reviewRequests(last: 10) {
           nodes {
             requestedReviewer {
               __typename
               ... on User {
                 login
+              }
+            }
+          }
+        }
+        # TODO: #181
+        reviews(last: 10) {
+          totalCount
+          nodes {
+            author {
+              __typename
+              ... on User {
+                login
+              }
+            }
+            state
+            body
+            url
+            createdAt
+            publishedAt
+            submittedAt
+            isMinimized
+            # TODO: #181
+            comments(last: 100) {
+              totalCount
+              nodes {
+                body
+                createdAt
+                updatedAt
+                author {
+                  __typename
+                  ... on User {
+                    login
+                  }
+                }
+              }
+            }
+          }
+        }
+        # TODO: #181
+        commits(last: 20) {
+          totalCount
+          nodes {
+            commit {
+              additions
+              deletions
+              message
+              messageBody
+              author {
+                user {
+                  login
+                }
+              }
+              changedFilesIfAvailable
+              committedDate
+              committer {
+                user {
+                  login
+                }
               }
             }
           }


### PR DESCRIPTION
Closes #170
- Added new fields (specified in #170) to the `PullRequests` GraphQL query.
- Extended `GitHubPullRequests` to store the additional data.
- Implemented support for nested types like labels, comments, reviews, and commits.
- Derived `Serialize`/`Deserialize` for new types to enable database storage.