### PR TITLE
Add statistics for resolved issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added new statistics to GraphQL API `issueStat` query. A field
+  `resolvedIssueCount` is added, indicating the number of resolved issues.
+  Currently, an issue is defined to be resolved if and only if (1) it is
+  "Closed" and (2) status of project item "to-do list" is "Done".
 - Tracing with a filter set by `RUST_LOG` environment variable.
 - Added support for passing the SSH passphrase through the `SSH_PASSPHRASE`
   environment variable.

--- a/src/database/issue.rs
+++ b/src/database/issue.rs
@@ -93,6 +93,8 @@ pub(crate) struct GitHubProjectV2ItemConnection {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub(crate) struct GitHubProjectV2Item {
+    pub(crate) project_id: String,
+    pub(crate) project_title: String,
     pub(crate) id: String,
     pub(crate) todo_status: Option<String>,
     pub(crate) todo_priority: Option<String>,
@@ -267,6 +269,8 @@ impl TryFrom<IssuesRepositoryIssuesNodesProjectItems> for GitHubProjectV2ItemCon
 impl From<IssuesRepositoryIssuesNodesProjectItemsNodes> for GitHubProjectV2Item {
     fn from(node: IssuesRepositoryIssuesNodesProjectItemsNodes) -> Self {
         Self {
+            project_id: node.project.id,
+            project_title: node.project.title,
             id: node.id,
             todo_status: node.todo_status.and_then(|status| match status {
                 TodoStatus::ProjectV2ItemFieldSingleSelectValue(inner) => inner.name,

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -9,7 +9,6 @@ use tokio::time;
 use tracing::error;
 
 pub use self::pull_requests::{PullRequestReviewState, PullRequestState as PRPullRequestState};
-use crate::database::issue::GitHubProjectV2Item;
 use crate::database::DiscussionDbSchema;
 use crate::{
     database::{issue::GitHubIssue, Database},
@@ -80,12 +79,6 @@ pub(crate) struct GitHubPRComment {
 pub(crate) struct GitHubPRCommentConnection {
     pub(crate) total_count: i32,
     pub(crate) nodes: Vec<GitHubPRComment>,
-}
-
-#[derive(Debug, Default, Deserialize, Serialize)]
-pub(crate) struct GitHubProjectV2ItemConnection {
-    pub(crate) total_count: i32,
-    pub(crate) nodes: Vec<GitHubProjectV2Item>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/outbound/graphql/issues.graphql
+++ b/src/outbound/graphql/issues.graphql
@@ -71,6 +71,10 @@ query Issues(
           totalCount
           nodes {
             __typename
+            project {
+              id
+              title
+            }
             id
             todoStatus: fieldValueByName(name: "Status") {
               __typename


### PR DESCRIPTION
- 2개의 GraphQL Query 를 구현함: `resolvedIssues`, `resolvedIssueStat`
- Resolved Issue 기준
  * 현재 명확히 합의된 Resolved Issue 의 기준은 없음.
  * 현재 구현에서는 PR 이 연결되어 auto-closed 된 issue 들만 추적함. 이슈 자신의 상태가 closed 이고, 연결된 PR 들의 상태가 모두 merged 인 이슈를 resolved issue 로 판단함. manually closed issue 중 어떤 것들을 resolved issue 로 판단할지는 추후 논의 예정
- Resolved Issue Statistics
  * 4가지 통계를 제공: `totalCount`, `latest`, `latestUpdated`, `latestClosed`
  * 논의 후 의미있는 통계를 추가하는 것이 필요해보임
- 구현한 2개의 GraphQL Query 들은 아래 쿼리들을 이용하여 테스트 했습니다.

```graphql
query ResolvedIssues(
  $repo: String
  $after: String
  $before: String
  $first: Int
  $last: Int
) {
  resolvedIssues(
    after: $after
    before: $before
    first: $first
    last: $last
    filter: { repo: $repo }
  ) {
    totalCount
    pageInfo {
      startCursor
      endCursor
      hasPreviousPage
      hasNextPage
    }
    edges {
      cursor
      node {
        repo
        owner
        number
        author
        createdAt
        updatedAt
        closedAt
        closedByPullRequests {
          number
          author
          state
        }
        comments {
          totalCount
          nodes {
            author
            body
            createdAt
            updatedAt
          }
        }
      }
    }
  }
}
```

```graphql
query ResolvedIssueStat($repo: String, $author: String, $assignee: String) {
  resolvedIssueStat(
    filter: { repo: $repo, author: $author, assignee: $assignee }
  ) {
    totalCount
    latest
    latestUpdated
    latestClosed
  }
}
```



Close #186 