### PR TITLE
Add `avg_review_comment_count` to `PullRequestStat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   (creation date range). The query returns the following fields:
   - `openPrCount`: The number of open pull requests.
   - `mergedPrCount`: The number of merged pull requests.
+  - `avgReviewCommentCount`: The average number of reviews and comments per
+    merged pull request.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "git2",
  "graphql_client",
  "jiff",
+ "num-traits",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ bincode = "1"
 clap = { version = "4", features = ["derive"] }
 config = { version = "0.15", features = ["toml"], default-features = false }
 directories = "6"
+fjall = "2"
 git2 = "0.20"
-
 graphql_client = "0.14"
 jiff = { version = "0.2", features = ["serde"] }
+num-traits = "0.2"
 regex = "1"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-fjall = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 toml = "0.8"
 tracing = "0.1"

--- a/src/api/pull_request_stat.rs
+++ b/src/api/pull_request_stat.rs
@@ -1,4 +1,6 @@
+use anyhow::Context as AnyhowContext;
 use async_graphql::{Context, InputObject, Object, Result, SimpleObject};
+use num_traits::ToPrimitive;
 
 use crate::{
     api::{pull_request::PullRequest, DateTimeUtc},
@@ -43,12 +45,20 @@ impl PullRequestStatFilter {
 #[derive(Default)]
 pub(super) struct PullRequestStatQuery {}
 
+/// `allow(clippy::struct_field_names)`: This warning is triggered by `_count` suffix in field
+/// names. In #222, an `avgMergeDays` field will be added to this struct, allowing us to remove this
+/// lint allowance.
+#[allow(clippy::struct_field_names)]
 #[derive(SimpleObject)]
 struct PullRequestStat {
     /// The number of open pull requests.
     open_pr_count: i32,
     /// The number of merged pull requests.
     merged_pr_count: i32,
+    /// The average number of reviews and comments per merged pull request.
+    ///
+    /// This field is `None` if there are no merged pull requests.
+    avg_review_comment_count: Option<f64>,
 }
 
 #[Object]
@@ -68,15 +78,34 @@ impl PullRequestStatQuery {
             .count()
             .try_into()?;
 
-        let merged_pr_count = filtered
+        let merged_prs: Vec<&PullRequest> = filtered
             .iter()
             .filter(|pr| matches!(pr.state, PullRequestState::MERGED))
-            .count()
-            .try_into()?;
+            .collect();
+        let merged_pr_count = merged_prs.len().try_into()?;
+        // Calculate average reviews and comments for merged pull requests
+        let avg_review_comment_count = if merged_prs.is_empty() {
+            None
+        } else {
+            let total_reviews_and_comments: f64 = merged_prs
+                .iter()
+                .map(|pr| pr.comments_count + pr.reviews_count)
+                .sum::<i32>()
+                .into();
+
+            Some(
+                total_reviews_and_comments
+                    / merged_prs
+                        .len()
+                        .to_f64()
+                        .context("Failed to convert usize to f64")?,
+            )
+        };
 
         Ok(PullRequestStat {
             open_pr_count,
             merged_pr_count,
+            avg_review_comment_count,
         })
     }
 }
@@ -331,5 +360,283 @@ mod tests {
         let data = schema.execute(query).await.data.into_json().unwrap();
         assert_eq!(data["pullRequestStat"]["openPrCount"], 0);
         assert_eq!(data["pullRequestStat"]["mergedPrCount"], 0);
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_no_merged_prs() {
+        let schema = TestSchema::new();
+        let prs = create_pull_requests(2); // All PRs are OPEN by default
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        let query = "
+        {
+            pullRequestStat(filter: {}) {
+                avgReviewCommentCount
+            }
+        }";
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        assert_eq!(
+            data["pullRequestStat"]["avgReviewCommentCount"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_single_merged_pr() {
+        let schema = TestSchema::new();
+        let mut prs = create_pull_requests(1);
+        prs[0].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[0].comments.total_count = 3;
+        prs[0].reviews.total_count = 2;
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        let query = "
+        {
+            pullRequestStat(filter: {}) {
+                avgReviewCommentCount
+            }
+        }";
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], 5.0);
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_multiple_merged_prs() {
+        let schema = TestSchema::new();
+        let mut prs = create_pull_requests(3);
+
+        // First merged PR: 4 comments + 1 review = 5 total
+        prs[0].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[0].comments.total_count = 4;
+        prs[0].reviews.total_count = 1;
+
+        // Second merged PR: 2 comments + 3 reviews = 5 total
+        prs[1].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[1].comments.total_count = 2;
+        prs[1].reviews.total_count = 3;
+
+        // Third PR is OPEN and should not affect the calculation
+        prs[2].comments.total_count = 10;
+        prs[2].reviews.total_count = 10;
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        let query = "
+        {
+            pullRequestStat(filter: {}) {
+                avgReviewCommentCount
+            }
+        }";
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        // Average: (5 + 5) / 2 = 5.0
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], 5.0);
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_with_zero_comments_and_reviews() {
+        let schema = TestSchema::new();
+        let mut prs = create_pull_requests(2);
+
+        // Both PRs are merged but have no comments or reviews
+        prs[0].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[0].comments.total_count = 0;
+        prs[0].reviews.total_count = 0;
+
+        prs[1].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[1].comments.total_count = 0;
+        prs[1].reviews.total_count = 0;
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        let query = "
+        {
+            pullRequestStat(filter: {}) {
+                avgReviewCommentCount
+            }
+        }";
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        // Average: (0 + 0) / 2 = 0.0
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], 0.0);
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_mixed_states() {
+        let schema = TestSchema::new();
+        let mut prs = create_pull_requests(4);
+
+        // MERGED PR: 6 comments + 2 reviews = 8 total
+        prs[0].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[0].comments.total_count = 6;
+        prs[0].reviews.total_count = 2;
+
+        // CLOSED PR: should not be included
+        prs[1].state = crate::outbound::PRPullRequestState::CLOSED;
+        prs[1].comments.total_count = 5;
+        prs[1].reviews.total_count = 5;
+
+        // MERGED PR: 1 comment + 1 review = 2 total
+        prs[2].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[2].comments.total_count = 1;
+        prs[2].reviews.total_count = 1;
+
+        // OPEN PR: should not be included
+        prs[3].comments.total_count = 100;
+        prs[3].reviews.total_count = 100;
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        let query = "
+        {
+            pullRequestStat(filter: {}) {
+                avgReviewCommentCount
+            }
+        }";
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        // Average: (8 + 2) / 2 = 5.0
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], 5.0);
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_with_filters() {
+        let schema = TestSchema::new();
+        let mut prs = create_pull_requests(3);
+
+        // MERGED PR by author "alice": 3 comments + 3 reviews = 6 total
+        prs[0].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[0].author = "alice".to_string();
+        prs[0].comments.total_count = 3;
+        prs[0].reviews.total_count = 3;
+
+        // MERGED PR by author "bob": 4 comments + 2 reviews = 6 total
+        prs[1].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[1].author = "bob".to_string();
+        prs[1].comments.total_count = 4;
+        prs[1].reviews.total_count = 2;
+
+        // MERGED PR by author "alice": 2 comments + 4 reviews = 6 total
+        prs[2].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[2].author = "alice".to_string();
+        prs[2].comments.total_count = 2;
+        prs[2].reviews.total_count = 4;
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        // Test filtering by author "alice"
+        let query = r#"
+        {
+            pullRequestStat(filter: {author: "alice"}) {
+                avgReviewCommentCount
+            }
+        }"#;
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        // Average for alice: (6 + 6) / 2 = 6.0
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], 6.0);
+
+        // Test filtering by author "bob"
+        let query = r#"
+        {
+            pullRequestStat(filter: {author: "bob"}) {
+                avgReviewCommentCount
+            }
+        }"#;
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        // Average for bob: 6 / 1 = 6.0
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], 6.0);
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_precision() {
+        let schema = TestSchema::new();
+        let mut prs = create_pull_requests(3);
+
+        // Three merged PRs with different comment/review counts to test precision
+        prs[0].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[0].comments.total_count = 1;
+        prs[0].reviews.total_count = 0; // Total: 1
+
+        prs[1].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[1].comments.total_count = 0;
+        prs[1].reviews.total_count = 1; // Total: 1
+
+        prs[2].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[2].comments.total_count = 1;
+        prs[2].reviews.total_count = 1; // Total: 2
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        let query = "
+        {
+            pullRequestStat(filter: {}) {
+                avgReviewCommentCount
+            }
+        }";
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        // Average: (1 + 1 + 2) / 3 = 4/3 ≈ 1.3333333333333333
+        let expected = 4.0 / 3.0;
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], expected);
+    }
+
+    #[tokio::test]
+    async fn avg_review_comment_count_combined_with_open_count() {
+        let schema = TestSchema::new();
+        let mut prs = create_pull_requests(4);
+
+        // OPEN PR
+        prs[0].comments.total_count = 1;
+        prs[0].reviews.total_count = 1;
+
+        // MERGED PR: 2 comments + 1 review = 3 total
+        prs[1].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[1].comments.total_count = 2;
+        prs[1].reviews.total_count = 1;
+
+        // OPEN PR
+        prs[2].comments.total_count = 5;
+        prs[2].reviews.total_count = 5;
+
+        // MERGED PR: 4 comments + 3 reviews = 7 total
+        prs[3].state = crate::outbound::PRPullRequestState::MERGED;
+        prs[3].comments.total_count = 4;
+        prs[3].reviews.total_count = 3;
+
+        schema
+            .db
+            .insert_pull_requests(prs, "aicers", "github-dashboard-server")
+            .unwrap();
+
+        let query = "
+        {
+            pullRequestStat(filter: {}) {
+                openPrCount
+                avgReviewCommentCount
+            }
+        }";
+        let data = schema.execute(query).await.data.into_json().unwrap();
+        assert_eq!(data["pullRequestStat"]["openPrCount"], 2);
+        // Average: (3 + 7) / 2 = 5.0
+        assert_eq!(data["pullRequestStat"]["avgReviewCommentCount"], 5.0);
     }
 }


### PR DESCRIPTION
Added `avg_review_comment_count` to the `PullRequestStat` struct, which calculates the average number of reviews and comments per merged pull request.

Closes #221