### PR TITLE
Add average days to merged PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `mergedPrCount`: The number of merged pull requests.
   - `avgReviewCommentCount`: The average number of reviews and comments per
     merged pull request.
+  - `avgMergeDays`: The average number of days from creation to merge for a pull
+    request.
 
 ### Changed
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -37,7 +37,7 @@ pub(crate) struct Query(
 
 pub(crate) type Schema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 pub(crate) struct DateTimeUtc(Timestamp);
 
 #[Scalar]


### PR DESCRIPTION
- Close #222
- Description
   - Implement `Sub` trait for `DateTimeUtc` to calculate day difference
   - The following code did not work as expected for reasons I couldn’t identify. Therefore, I implemented the functionality as shown in this PR.
     ```rust
       fn sub(self, rhs: Self) -> Self::Output {
        self.0.sub(rhs.0).get_days()
      }
      ``` 